### PR TITLE
Handle errors from external api calls, with retry when appropriate

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/KuhrSarClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/KuhrSarClient.kt
@@ -1,10 +1,12 @@
 package no.nav.syfo.client
 
 import io.ktor.client.HttpClient
+import io.ktor.client.call.*
 import io.ktor.client.request.accept
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
-import io.ktor.http.ContentType
+import io.ktor.client.statement.*
+import io.ktor.http.*
 import io.ktor.util.KtorExperimentalAPI
 import java.util.Date
 import kotlin.math.max
@@ -15,6 +17,7 @@ import no.nav.syfo.log
 import no.nav.syfo.model.SamhandlerPraksisType
 import no.nav.syfo.util.LoggingMeta
 import org.apache.commons.text.similarity.LevenshteinDistance
+import java.io.IOException
 
 @KtorExperimentalAPI
 class SarClient(
@@ -22,9 +25,13 @@ class SarClient(
     private val httpClient: HttpClient
 ) {
     suspend fun getSamhandler(ident: String): List<Samhandler> = retry("get_samhandler") {
-        httpClient.get<List<Samhandler>>("$endpointUrl/rest/sar/samh") {
+        val response: HttpResponse = httpClient.get("$endpointUrl/rest/sar/samh") {
             accept(ContentType.Application.Json)
             parameter("ident", ident)
+        }
+        when(response.status) {
+            HttpStatusCode.OK -> response.receive()
+            else -> throw IOException("Vi fikk en uventet feil fra kuhrSar, prøver på nytt! ${response.content}")
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/client/Padm2ReglerClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/Padm2ReglerClient.kt
@@ -1,22 +1,31 @@
 package no.nav.syfo.client
 
 import io.ktor.client.HttpClient
+import io.ktor.client.call.*
 import io.ktor.client.request.accept
 import io.ktor.client.request.post
-import io.ktor.http.ContentType
-import io.ktor.http.contentType
+import io.ktor.client.statement.*
+import io.ktor.http.*
 import io.ktor.util.KtorExperimentalAPI
 import no.nav.syfo.helpers.retry
 import no.nav.syfo.model.ReceivedDialogmelding
 import no.nav.syfo.model.ValidationResult
+import java.io.IOException
 
 @KtorExperimentalAPI
 class Padm2ReglerClient(private val endpointUrl: String, private val client: HttpClient) {
     suspend fun executeRuleValidation(payload: ReceivedDialogmelding): ValidationResult = retry("padm2regler_validate") {
-        client.post<ValidationResult>("$endpointUrl/v1/rules/validate") {
+        val response: HttpResponse = client.post("$endpointUrl/v1/rules/validate") {
             contentType(ContentType.Application.Json)
             accept(ContentType.Application.Json)
             body = payload
+        }
+
+        when(response.status) {
+            HttpStatusCode.InternalServerError -> throw RuntimeException("Fikk en feil fra padm2regler som ikke vi ikke kjører retry for ${response.content}")
+            HttpStatusCode.ServiceUnavailable -> throw IOException("Fikk en feil fra padm2regler som kan retryes ${response.content}")
+            HttpStatusCode.OK -> response.receive()
+            else -> throw IOException("Vi fikk en uventet feil fra padm2regler, prøver på nytt! ${response.content}")
         }
     }
 }


### PR DESCRIPTION
Tidligere har vi prøvd å mappe om til objekt med én gang, men hvis vi får en feilmelding av type text tilbake, klarer vi ikke å konvertere fordi det ikke er json, og vi ender opp med en exception.
Nå sjekker vi hva status er før vi mapper om til objekt, eller kaster exception.