### PR TITLE
Create one Dokument per vedlegg

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/DokArkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/DokArkivClient.kt
@@ -127,7 +127,7 @@ fun leggtilDokument(
                 Dokument(
                     dokumentvarianter = listOf(
                         Dokumentvarianter(
-                            filtype = "PDFA", // Markerer alle filer som type "PDFA" for at Joark skal godta at de får variantformat "ARKIV"
+                            filtype = findFiltype(it),
                             filnavn = when (it.beskrivelse.length >= 200) {
                                 true -> "${it.beskrivelse.substring(0, 199)}.${findFiltype(it).toLowerCase()}"
                                 else -> "${it.beskrivelse}.${findFiltype(it).toLowerCase()}"

--- a/src/main/kotlin/no/nav/syfo/client/DokArkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/DokArkivClient.kt
@@ -121,29 +121,32 @@ fun leggtilDokument(
         )
     )
     if (!vedleggListe.isNullOrEmpty()) {
-        val listDokumentvarianter = ArrayList<Dokumentvarianter>()
+        val listVedleggDokumenter = ArrayList<Dokument>()
         vedleggListe.map {
-            listDokumentvarianter.add(
-                Dokumentvarianter(
-                    filtype = findFiltype(it),
-                    filnavn = when (it.beskrivelse.length >= 200) {
-                        true -> "${it.beskrivelse.substring(0, 199)}.${findFiltype(it).toLowerCase()}"
-                        else -> "${it.beskrivelse}.${findFiltype(it).toLowerCase()}"
-                    },
-                    variantformat = when (it.mimeType == "application/pdf") {
-                        true -> "ARKIV"
-                        else -> "ORIGINAL"
-                    },
-                    fysiskDokument = it.contentBase64
+            listVedleggDokumenter.add(
+                Dokument(
+                    dokumentvarianter = listOf(
+                        Dokumentvarianter(
+                            filtype = findFiltype(it),
+                            filnavn = when (it.beskrivelse.length >= 200) {
+                                true -> "${it.beskrivelse.substring(0, 199)}.${findFiltype(it).toLowerCase()}"
+                                else -> "${it.beskrivelse}.${findFiltype(it).toLowerCase()}"
+                            },
+                            variantformat = when (it.mimeType == "application/pdf") {
+                                true -> "ARKIV"
+                                else -> "ORIGINAL"
+                            },
+                            fysiskDokument = it.contentBase64
+                        )
+                    ),
+                    tittel = "Vedlegg til dialogmelding"
                 )
             )
         }
-        listDokument.add(
-            Dokument(
-                dokumentvarianter = listDokumentvarianter,
-                tittel = "Vedlegg til dialogmelding"
-            )
-        )
+
+        listVedleggDokumenter.map { vedlegg ->
+            listDokument.add(vedlegg)
+        }
     }
 
     return listDokument

--- a/src/main/kotlin/no/nav/syfo/client/DokArkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/DokArkivClient.kt
@@ -127,15 +127,12 @@ fun leggtilDokument(
                 Dokument(
                     dokumentvarianter = listOf(
                         Dokumentvarianter(
-                            filtype = findFiltype(it),
+                            filtype = "PDFA", // Markerer alle filer som type "PDFA" for at Joark skal godta at de får variantformat "ARKIV"
                             filnavn = when (it.beskrivelse.length >= 200) {
                                 true -> "${it.beskrivelse.substring(0, 199)}.${findFiltype(it).toLowerCase()}"
                                 else -> "${it.beskrivelse}.${findFiltype(it).toLowerCase()}"
                             },
-                            variantformat = when (it.mimeType == "application/pdf") {
-                                true -> "ARKIV"
-                                else -> "ORIGINAL"
-                            },
+                            variantformat = "ARKIV",
                             fysiskDokument = it.contentBase64
                         )
                     ),


### PR DESCRIPTION
Før denne fiksen, feiler det hvis vi har to pdf-vedlegg, fordi dokarkiv ikke godtar at vi får to varianter av typen "ARKIV"