### PR TITLE
Ignore Foresporsel tag in XML of type dialog_notat/henvendelse fra lege

### DIFF
--- a/src/main/kotlin/no/nav/syfo/model/DialogmeldingMapper.kt
+++ b/src/main/kotlin/no/nav/syfo/model/DialogmeldingMapper.kt
@@ -39,7 +39,7 @@ fun XMLNotat.toHenvendelseFraLegeHenvendelse(): HenvendelseFraLegeHenvendelse {
         teamakode = temaKodet.toTeamakode(),
         tekstNotatInnhold = tekstNotatInnhold.toString(),
         dokIdNotat = dokIdNotat,
-        foresporsel = foresporsel?.toForesporsel(),
+        foresporsel = null, // Ignore because EPJ send incorrect data and we don't use it
         rollerRelatertNotat = if (rollerRelatertNotat.isNotEmpty()) {
             RollerRelatertNotat(
                 rolleNotat = if (rollerRelatertNotat.firstOrNull()?.person != null) {

--- a/src/test/resources/dialogmelding_dialog_notat.xml
+++ b/src/test/resources/dialogmelding_dialog_notat.xml
@@ -100,6 +100,14 @@
                             <TekstNotatInnhold xsi:type="xsd:string">Hei,Det gjelder pas. Sender som vedlegg epikrisen</TekstNotatInnhold>
                             <DokIdNotat>A1578B81-0042-453B-8527-6CF182BDA6C7</DokIdNotat>
                             <DatoNotat>2019-01-16</DatoNotat>
+                            <Foresporsel>
+                                <TypeForesp DN="Påminnelse forespørsel om pasient" S="2.16.578.1.12.4.1.1.8129" V="2"/>
+                                <Sporsmal>
+                                    The Foresporsel tag including content is currently ignored if the dialogmelding is
+                                    of type dialog_notat/henvendelse fra lege. This is necessary because EPJs were
+                                    allowed to send incorrect XML to previous system EIA.
+                                </Sporsmal>
+                            </Foresporsel>
                         </Notat>
                     </Dialogmelding>
                 </Content>


### PR DESCRIPTION
This is necessary because EPJs were allowed to send incorrect data to
previous system EIA. Even if the EPJ did send correct XML we're currently
not using the information.

In the future, when we start threading messages, we'll need to make sure
they also send the required information to identify the original message
they're responding to.