### PR TITLE
Filter out empty vedlegg before creating Dokumenter

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/DokArkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/DokArkivClient.kt
@@ -126,6 +126,7 @@ fun leggtilDokument(
     if (!vedleggListe.isNullOrEmpty()) {
         val listVedleggDokumenter = ArrayList<Dokument>()
         vedleggListe
+            .filter { vedlegg -> vedlegg.contentBase64.isNotEmpty() }
             .map { vedlegg -> vedleggToPDF(vedlegg) }
             .map {
             listVedleggDokumenter.add(


### PR DESCRIPTION
Da vil vi unngå at lagring i Joark feiler pga ugyldig Dokument.
Dette gjør at dialogmeldingen vil gå gjennom som normalt, uten feil, men ingen får beskjed om at vi har ignorert det tomme vedlegget.