### PR TITLE
Fix number of replicas for redis

### DIFF
--- a/redis.yaml
+++ b/redis.yaml
@@ -10,7 +10,7 @@ spec:
   port: 6379
   replicas:
     min: 1
-    max: 4
+    max: 1
   resources:
     limits:
       cpu: 250m


### PR DESCRIPTION
No more than 1 replica works with NAIS.