### PR TITLE
Build jar first, then build and push docker image.

### DIFF
--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -23,11 +23,30 @@ jobs:
           found=$(echo "$manifest" | grep "schemaVersion" || true)
           echo ${found}
           echo "found_image=$found" >> $GITHUB_ENV
+      - name: Setup java
+        if: ${{ !env.found_image }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: '14'
       - name: Checkout code
         if: ${{ !env.found_image }}
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.gitCommit }}
+      - name: Run tests
+        if: ${{ !env.found_image }}
+        env:
+          ORG_GRADLE_PROJECT_githubUser: x-access-token
+          ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./gradlew test
+      - name: Build jar
+        if: ${{ !env.found_image }}
+        env:
+          ORG_GRADLE_PROJECT_githubUser: x-access-token
+          ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./gradlew shadowJar -x test
       - name: Build and publish Docker image if not already done
         if: ${{ !env.found_image }}
         env:
@@ -42,7 +61,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}


### PR DESCRIPTION
Set up java, run tests and build a jar package before building and
publishing the docker image. The build docker image step runs the
app's Docker file, which requires a jar file to work.

Also switch to actions/checkout@v2, it should be quicker, see
https://github.com/actions/checkout