### PR TITLE
Reject incoming message if duplicate

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -9,7 +9,7 @@ spec:
   image: {{ image }}
   replicas:
     min: 1
-    max: 2
+    max: 1
     cpuThresholdPercentage: 90
   port: 8080
   liveness:

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   image: {{ image }}
   replicas:
-    min: 2
-    max: 4
+    min: 1
+    max: 1
     cpuThresholdPercentage: 90
   port: 8080
   liveness:

--- a/src/main/kotlin/no/nav/syfo/application/BlockingApplicationRunner.kt
+++ b/src/main/kotlin/no/nav/syfo/application/BlockingApplicationRunner.kt
@@ -166,23 +166,12 @@ class BlockingApplicationRunner {
                             }
                         }
 
-                        val redisSha256String = jedis.get(sha256String)
-                        val redisEdiloggid = jedis.get(ediLoggId)
-
-                        if (redisSha256String != null) {
-                            handleDuplicateSM2013Content(
+                        if (dialogmeldingDokumentWithShaExists(sha256String, database)) {
+                            handleDuplicateDialogmeldingContent(
                                 session, receiptProducer,
-                                fellesformat, loggingMeta, env, redisSha256String
+                                fellesformat, loggingMeta, env, sha256String
                             )
                             continue@loop
-                        } else if (redisEdiloggid != null) {
-                            handleDuplicateEdiloggid(
-                                session, receiptProducer,
-                                fellesformat, loggingMeta, env, redisEdiloggid
-                            )
-                            continue@loop
-                        } else {
-                            updateRedis(jedis, ediLoggId, sha256String)
                         }
 
                         val patientIdents = aktoerIds[personNumberPatient]

--- a/src/main/kotlin/no/nav/syfo/handlestatus/HandleStatusInvalid.kt
+++ b/src/main/kotlin/no/nav/syfo/handlestatus/HandleStatusInvalid.kt
@@ -59,21 +59,20 @@ suspend fun handleStatusINVALID(
     log.info("Apprec Receipt sent to {}, {}", apprecQueueName, fields(loggingMeta))
 }
 
-fun handleDuplicateSM2013Content(
+fun handleDuplicateDialogmeldingContent(
     session: Session,
     receiptProducer: MessageProducer,
     fellesformat: XMLEIFellesformat,
     loggingMeta: LoggingMeta,
     env: Environment,
-    redisSha256String: String
+    sha256String: String,
 ) {
-
     log.warn(
-        "Duplicate message: Same redisSha256String {}",
+        "Duplicate message: Same sha256String {}",
         createLogEntry(
             LogType.INVALID_MESSAGE,
             loggingMeta,
-            "originalEdiLoggId" to redisSha256String,
+            "shaString" to sha256String,
         )
     )
 
@@ -82,38 +81,6 @@ fun handleDuplicateSM2013Content(
             createApprecError(
                 "Duplikat! - Denne dialogmeldingen er mottatt tidligere. " +
                         "Skal ikke sendes på nytt."
-            )
-        )
-    )
-    log.info("Apprec Receipt sent to {}, {}", env.apprecQueueName, fields(loggingMeta))
-    INVALID_MESSAGE_NO_NOTICE.inc()
-}
-
-fun handleDuplicateEdiloggid(
-    session: Session,
-    receiptProducer: MessageProducer,
-    fellesformat: XMLEIFellesformat,
-    loggingMeta: LoggingMeta,
-    env: Environment,
-    redisEdiloggid: String
-) {
-
-    log.warn(
-        "Duplicate message: Same redisEdiloggid {}",
-        createLogEntry(
-            LogType.INVALID_MESSAGE,
-            loggingMeta,
-            "originalEdiLoggId" to redisEdiloggid,
-        )
-    )
-
-    sendReceipt(
-        session, receiptProducer, fellesformat, ApprecStatus.avvist, listOf(
-            createApprecError(
-                "Dialogmeldingen kan ikke rettes, det må skrives en ny. Grunnet følgende:" +
-                        "Denne dialogmeldingen har ein identisk identifikator med ein dialogmeldingen som er mottatt tidligere," +
-                        " og er derfor ein duplikat." +
-                        " og skal ikke sendes på nytt. Dersom dette ikke stemmer, kontakt din EPJ-leverandør"
             )
         )
     )

--- a/src/main/kotlin/no/nav/syfo/persistering/db/PersisterDialogmeldingQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/persistering/db/PersisterDialogmeldingQueries.kt
@@ -99,6 +99,20 @@ fun Connection.erDialogmeldingOpplysningerLagret(dialogmeldingid: String) =
         }
     }
 
+fun Connection.hasSavedDialogmeldingDokument(shaString: String): Boolean =
+    use { connection ->
+        connection.prepareStatement(
+            """
+                SELECT *
+                FROM DIALOGMELDINGDOKUMENT
+                WHERE sha_string=?;
+                """
+        ).use {
+            it.setString(1, shaString)
+            it.executeQuery().next()
+        }
+    }
+
 fun Dialogmelding.toPGObject() = PGobject().also {
     it.type = "json"
     it.value = objectMapper.writeValueAsString(this)

--- a/src/main/kotlin/no/nav/syfo/services/DialogmeldingDokumentService.kt
+++ b/src/main/kotlin/no/nav/syfo/services/DialogmeldingDokumentService.kt
@@ -1,0 +1,11 @@
+package no.nav.syfo.services
+
+import no.nav.syfo.db.Database
+import no.nav.syfo.persistering.db.hasSavedDialogmeldingDokument
+
+fun dialogmeldingDokumentWithShaExists(
+    sha256String: String,
+    database: Database
+): Boolean {
+    return database.connection.hasSavedDialogmeldingDokument(sha256String)
+}


### PR DESCRIPTION
Sjekk om det finnes dialomgeldingdokument med samme sha som den nye meldingen.
Hvis duplikat, håndter det likt som før: Send negativ AppRec og gå videre til neste melding.
Gå ned til 1 pod for å unngå at duplikater kommer samtidig på hver sin pod.
Fjern Redis-sjekk, men behold lagring til redis inne i "handle"-metodene enn så lenge.