### PR TITLE
Handle unrecognized kodeverk

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/BlockingApplicationRunner.kt
+++ b/src/main/kotlin/no/nav/syfo/application/BlockingApplicationRunner.kt
@@ -25,7 +25,7 @@ import no.nav.syfo.metrics.REQUEST_TIME
 import no.nav.syfo.model.*
 import no.nav.syfo.services.*
 import no.nav.syfo.util.*
-import no.nav.syfo.validation.validateDialogMeldingKodeverk
+import no.nav.syfo.validation.isKodeverkValid
 import java.io.StringReader
 import java.time.ZoneOffset
 import java.util.*
@@ -206,7 +206,7 @@ class BlockingApplicationRunner {
                             continue@loop
                         }
 
-                        if (!validateDialogMeldingKodeverk(dialogmeldingXml, dialogmeldingType)) {
+                        if (!isKodeverkValid(dialogmeldingXml, dialogmeldingType)) {
                             handleInvalidDialogMeldingKodeverk(
                                 session, receiptProducer, fellesformat, env, loggingMeta
                             )

--- a/src/main/kotlin/no/nav/syfo/model/DialogmeldingMapper.kt
+++ b/src/main/kotlin/no/nav/syfo/model/DialogmeldingMapper.kt
@@ -71,7 +71,7 @@ fun XMLNotat.toHenvendelseFraLegeHenvendelse(): HenvendelseFraLegeHenvendelse {
 }
 
 fun CV.toTeamakode(): TemaKode {
-    return findDialogmeldingKodeverk(s, v).toTypeMelding()
+    return findDialogmeldingKodeverk(s, v)!!.toTypeMelding()
 }
 
 fun DialogmeldingKodeverk.toTypeMelding(): TemaKode {

--- a/src/main/kotlin/no/nav/syfo/model/DialogmeldingType.kt
+++ b/src/main/kotlin/no/nav/syfo/model/DialogmeldingType.kt
@@ -1,5 +1,7 @@
 package no.nav.syfo.model
 
+import no.nav.syfo.log
+
 enum class DialogmeldingType(val ebxmlService: String, val ebxmlAction: String, val dialogmeldingKodeverk: List<DialogmeldingKodeverk>, val brevkode: String) {
     DIALOGMELDING_DIALOGMOTE_INNKALLING_MOTERESPONS("DialogmoteInnkalling", "MoteRespons", listOf(
         DialogmeldingKodeverk.SVAR_PAA_INNKALLING_DIALOGMOTE_JA_JEG_KOMMER,
@@ -19,6 +21,12 @@ fun findDialogmeldingType(ebxmlService: String, ebxmlAction: String): Dialogmeld
     return DialogmeldingType.values().first { it.ebxmlService == ebxmlService && it.ebxmlAction == ebxmlAction }
 }
 
-fun findDialogmeldingKodeverk(kodeverkOID: String, v: String): DialogmeldingKodeverk {
-    return DialogmeldingKodeverk.values().first { it.kodeverkOID == kodeverkOID && it.v == v }
+fun findDialogmeldingKodeverk(kodeverkOID: String, v: String): DialogmeldingKodeverk? {
+    val kodeverk = DialogmeldingKodeverk.values().firstOrNull { it.kodeverkOID == kodeverkOID && it.v == v }
+
+    if (kodeverk == null) {
+        log.warn("Fant ikke kodeverk som matcher dialogmeldingen. kodeverkOID: $kodeverkOID, v: $v")
+    }
+
+    return kodeverk
 }

--- a/src/main/kotlin/no/nav/syfo/validation/ValidateDialogMeldingKodeverk.kt
+++ b/src/main/kotlin/no/nav/syfo/validation/ValidateDialogMeldingKodeverk.kt
@@ -4,7 +4,7 @@ import no.nav.helse.dialogmelding.XMLDialogmelding
 import no.nav.syfo.model.DialogmeldingType
 import no.nav.syfo.model.findDialogmeldingKodeverk
 
-fun validateDialogMeldingKodeverk(xmlDialogmelding: XMLDialogmelding, dialogmeldingType: DialogmeldingType): Boolean {
+fun isKodeverkValid(xmlDialogmelding: XMLDialogmelding, dialogmeldingType: DialogmeldingType): Boolean {
 
     when (dialogmeldingType) {
         DialogmeldingType.DIALOGMELDING_DIALOGMOTE_INNKALLING_MOTERESPONS -> {

--- a/src/test/kotlin/no/nav/syfo/ValidateDialogMeldingKodeverkTest.kt
+++ b/src/test/kotlin/no/nav/syfo/ValidateDialogMeldingKodeverkTest.kt
@@ -8,7 +8,7 @@ import no.nav.syfo.util.extractDialogmelding
 import no.nav.syfo.util.fellesformatUnmarshaller
 import no.nav.syfo.util.get
 import no.nav.syfo.util.getFileAsString
-import no.nav.syfo.validation.validateDialogMeldingKodeverk
+import no.nav.syfo.validation.isKodeverkValid
 import org.amshove.kluent.shouldBe
 import org.junit.Test
 
@@ -25,7 +25,7 @@ internal class ValidateDialogMeldingKodeverkTest {
 
         val dialogmeldingType = findDialogmeldingType(receiverBlock.ebService, receiverBlock.ebAction)
 
-        val validateDialogMeldingKodeverk = validateDialogMeldingKodeverk(dialomeldingxml, dialogmeldingType)
+        val validateDialogMeldingKodeverk = isKodeverkValid(dialomeldingxml, dialogmeldingType)
 
         validateDialogMeldingKodeverk shouldBe false
     }
@@ -41,8 +41,26 @@ internal class ValidateDialogMeldingKodeverkTest {
 
         val dialogmeldingType = findDialogmeldingType(receiverBlock.ebService, receiverBlock.ebAction)
 
-        val validateDialogMeldingKodeverk = validateDialogMeldingKodeverk(dialomeldingxml, dialogmeldingType)
+        val validateDialogMeldingKodeverk = isKodeverkValid(dialomeldingxml, dialogmeldingType)
 
         validateDialogMeldingKodeverk shouldBe true
+    }
+
+    @Test
+    internal fun `Should be invalid if temakodet is not found in Kodeverklist`() {
+        val fellesformatDm = fellesformatUnmarshaller.unmarshal(
+            StringReader(getFileAsString("src/test/resources/dialogmelding_dialog_notat.xml"))
+        ) as XMLEIFellesformat
+
+        val dialogmeldingxml = extractDialogmelding(fellesformatDm)
+        dialogmeldingxml.notat.first().temaKodet.v = "INVALID"
+
+        val receiverBlock = fellesformatDm.get<XMLMottakenhetBlokk>()
+
+        val dialogmeldingType = findDialogmeldingType(receiverBlock.ebService, receiverBlock.ebAction)
+
+        val validateDialogMeldingKodeverk = isKodeverkValid(dialogmeldingxml, dialogmeldingType)
+
+        validateDialogMeldingKodeverk shouldBe false
     }
 }


### PR DESCRIPTION
Håndter null hvis meldingen har brukt et kodeverk/verdi vi ikke gjenkjenner, i stedet for å kaste exception.
Avvis melding hvis det er ukjent kodeverk, samme som når det er brukt kodeverk for feil meldingstype.
Bytt navn på valideringsmetoden.