### PR TITLE
Update MQ settings, use srv username/password for auth

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -36,8 +36,6 @@ spec:
   vault:
     enabled: true
     paths:
-      - kvPath: /kv/preprod/fss/padm2/default
-        mountPath: /secrets/default
       - kvPath: serviceuser/data/dev/srvpadm2
         mountPath: /secrets/serviceuser
       - kvPath: /azuread/data/dev/creds/padm2
@@ -49,11 +47,11 @@ spec:
     - name: MQ_INPUT_QUEUE_NAME
       value: QA.Q1_PADM.INPUT
     - name: MQ_HOST_NAME
-      value: b27apvl177.preprod.local
+      value: b27apvl222.preprod.local
     - name: MQ_PORT
       value: '1413'
     - name: MQ_GATEWAY_NAME
-      value: MQ1LSC04
+      value: MQLS04
     - name: MQ_CHANNEL_NAME
       value: Q1_PADM
     - name: AKTOR_REGISTER_V1_URL

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -36,8 +36,6 @@ spec:
   vault:
     enabled: true
     paths:
-      - kvPath: /kv/prod/fss/padm2/default
-        mountPath: /secrets/default
       - kvPath: serviceuser/data/prod/srvpadm2
         mountPath: /secrets/serviceuser
       - kvPath: /azuread/data/prod/creds/padm2
@@ -49,11 +47,11 @@ spec:
     - name: MQ_INPUT_QUEUE_NAME
       value: QA.P_PADM.INPUT
     - name: MQ_HOST_NAME
-      value: a01apvl064.adeo.no
+      value: a01apvl271.adeo.no
     - name: MQ_PORT
       value: '1414'
     - name: MQ_GATEWAY_NAME
-      value: MPLSC04
+      value: MPLS04
     - name: MQ_CHANNEL_NAME
       value: P_PADM
     - name: AKTOR_REGISTER_V1_URL

--- a/src/main/kotlin/no/nav/syfo/Bootstrap.kt
+++ b/src/main/kotlin/no/nav/syfo/Bootstrap.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.ibm.msg.client.jms.JmsConstants.USER_AUTHENTICATION_MQCSP
 import io.ktor.client.*
 import io.ktor.client.engine.apache.*
 import io.ktor.client.features.json.*
@@ -59,10 +60,8 @@ fun main() {
     val vaultSecrets = VaultSecrets(
         serviceuserPassword = getFileAsString("/secrets/serviceuser/password"),
         serviceuserUsername = getFileAsString("/secrets/serviceuser/username"),
-        mqUsername = getFileAsString("/secrets/default/mqUsername"),
-        mqPassword = getFileAsString("/secrets/default/mqPassword"),
         clientId = getFileAsString("/secrets/azuread/padm2/client_id"),
-        clientsecret = getFileAsString("/secrets/azuread/padm2/client_secret")
+        clientsecret = getFileAsString("/secrets/azuread/padm2/client_secret"),
     )
 
     val applicationServer = ApplicationServer(applicationEngine, applicationState)
@@ -162,7 +161,10 @@ fun launchListeners(
     signerendeLegeService: SignerendeLegeService
 ) {
     createListener(applicationState) {
-        connectionFactory(env).createConnection(secrets.mqUsername, secrets.mqPassword).use { connection ->
+        val factory = connectionFactory(env)
+        factory.setBooleanProperty(USER_AUTHENTICATION_MQCSP, true)
+
+        factory.createConnection(secrets.serviceuserUsername, secrets.serviceuserPassword).use { connection ->
             connection.start()
             val session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
 

--- a/src/main/kotlin/no/nav/syfo/Environment.kt
+++ b/src/main/kotlin/no/nav/syfo/Environment.kt
@@ -36,8 +36,6 @@ data class Environment(
 data class VaultSecrets(
     val serviceuserUsername: String,
     val serviceuserPassword: String,
-    val mqUsername: String,
-    val mqPassword: String,
     val clientId: String,
     val clientsecret: String
 )


### PR DESCRIPTION
Bruk ny MQ server og queue manager.
Bruk brukernavn og passord til servicebrukeren for autentisering, siden den nå har fått tilgang til en egen MQ-gruppe.
Legg til eksplisitt autentisering i connectionFactory.