### PR TITLE
Add support for dnr

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/ArenaDialogNotat.kt
+++ b/src/main/kotlin/no/nav/syfo/client/ArenaDialogNotat.kt
@@ -18,7 +18,7 @@ fun createArenaDialogNotat(
     fellesformat: XMLEIFellesformat,
     tssid: String?,
     legefnr: String,
-    pasientFnr: String,
+    innbyggerident: String,
     msgHead: XMLMsgHead,
     receiverBlock: XMLMottakenhetBlokk,
     dialogmelding: Dialogmelding
@@ -44,7 +44,7 @@ fun createArenaDialogNotat(
         }
         pasientData = PasientDataType().apply {
             person = PersonType().apply {
-                personFnr = pasientFnr
+                personFnr = innbyggerident
                 personNavn = NavnType().apply {
                     fornavn = msgHead.msgInfo.patient.givenName
                     mellomnavn = msgHead.msgInfo.patient?.middleName ?: ""

--- a/src/main/kotlin/no/nav/syfo/model/RuleMetadata.kt
+++ b/src/main/kotlin/no/nav/syfo/model/RuleMetadata.kt
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 data class RuleMetadata(
     val signatureDate: LocalDateTime,
     val receivedDate: LocalDateTime,
-    val patientPersonNumber: String,
+    val innbyggerident: String,
     val legekontorOrgnr: String?,
     val tssid: String?,
     val avsenderfnr: String

--- a/src/main/kotlin/no/nav/syfo/rules/ValidationRuleChain.kt
+++ b/src/main/kotlin/no/nav/syfo/rules/ValidationRuleChain.kt
@@ -13,23 +13,23 @@ enum class ValidationRuleChain(
     override val predicate: (RuleData<RuleMetadata>) -> Boolean
 ) : Rule<RuleData<RuleMetadata>> {
 
-    UGYLDIG_FNR_LENGDE_PASIENT(
+    UGYLDIG_INNBYGGERIDENT_LENGDE(
         1002,
         Status.INVALID,
         "Pasienten sitt fødselsnummer eller D-nummer er ikke 11 tegn.",
         "Pasienten sitt fødselsnummer eller D-nummer er ikke 11 tegn.",
         { (_, metadata) ->
-            !validatePersonAndDNumber11Digits(metadata.patientPersonNumber)
+            !validatePersonAndDNumber11Digits(metadata.innbyggerident)
         }
     ),
 
-    UGYLDIG_FNR_PASIENT(
+    UGYLDIG_INNBYGGERIDENT(
         1006,
         Status.INVALID,
-        "Fødselsnummer/D-nummer kan passerer ikke modulus 11",
+        "Fødselsnummer/D-nummer er ikke gyldig",
         "Pasientens fødselsnummer/D-nummer er ikke gyldig",
         { (_, metadata) ->
-            !validatePersonAndDNumber(metadata.patientPersonNumber)
+            !validatePersonAndDNumber(metadata.innbyggerident)
         }
     ),
 
@@ -43,13 +43,13 @@ enum class ValidationRuleChain(
         }
     ),
 
-    AVSENDER_FNR_ER_SAMME_SOM_PASIENT_FNR(
+    AVSENDER_FNR_ER_SAMME_SOM_INNBYGGER_FNR(
         9999,
         Status.INVALID,
         "Den som signert dialogmeldingen er også pasient.",
         "Avsender fnr er det samme som pasient fnr",
         { (_, metadata) ->
-            metadata.avsenderfnr.equals(metadata.patientPersonNumber)
+            metadata.avsenderfnr.equals(metadata.innbyggerident)
         }
     ),
 }

--- a/src/main/kotlin/no/nav/syfo/services/RuleService.kt
+++ b/src/main/kotlin/no/nav/syfo/services/RuleService.kt
@@ -73,7 +73,7 @@ class RuleService(
                     RuleMetadata(
                         receivedDate = receivedDialogmelding.mottattDato,
                         signatureDate = receivedDialogmelding.mottattDato,
-                        patientPersonNumber = receivedDialogmelding.personNrPasient,
+                        innbyggerident = receivedDialogmelding.personNrPasient,
                         legekontorOrgnr = receivedDialogmelding.legekontorOrgNr,
                         tssid = receivedDialogmelding.tssid,
                         avsenderfnr = receivedDialogmelding.personNrLege

--- a/src/main/kotlin/no/nav/syfo/util/ExtractFromFellesFormat.kt
+++ b/src/main/kotlin/no/nav/syfo/util/ExtractFromFellesFormat.kt
@@ -78,3 +78,8 @@ fun extractPasientNavn(fellesformat: XMLEIFellesformat): String =
             "${fellesformat.get<XMLMsgHead>().msgInfo.patient.middleName}"
 
 inline fun <reified T> XMLEIFellesformat.get() = this.any.find { it is T } as T
+
+fun extractInnbyggerident(fellesformat: XMLEIFellesformat): String? =
+    fellesformat.get<XMLMsgHead>().msgInfo.patient.ident.find {
+        it.typeId.v == "FNR" || it.typeId.v == "DNR"
+    }?.id

--- a/src/test/kotlin/no/nav/syfo/FromKiropraktorTest.kt
+++ b/src/test/kotlin/no/nav/syfo/FromKiropraktorTest.kt
@@ -60,7 +60,7 @@ class FromKiropraktorTest {
             fellesformat = fellesformat,
             tssid = TSS_ID,
             legefnr = receiverBlock.avsenderFnrFraDigSignatur,
-            pasientFnr = msgHead.msgInfo.patient.ident.find { it.typeId.v == "FNR" }?.id ?: "",
+            innbyggerident = extractInnbyggerident(fellesformat) ?: "",
             msgHead = msgHead,
             receiverBlock = receiverBlock,
             dialogmelding = dialogmelding

--- a/src/test/kotlin/no/nav/syfo/rules/ValidationRuleChainSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/rules/ValidationRuleChainSpek.kt
@@ -25,30 +25,44 @@ internal class ValidationRuleChainSpek {
     )
 
     @Test
-    internal fun `Should check rule UGYLDIG_FNR_LENGDE, should trigger rule`() {
-        ValidationRuleChain.UGYLDIG_FNR_LENGDE_PASIENT(
+    internal fun `Should check rule UGYLDIG_IDENT_LENGDE, should trigger rule`() {
+        ValidationRuleChain.UGYLDIG_INNBYGGERIDENT_LENGDE(
             ruleData(dialogmelding, patientPersonNumber = "3006310441")
         ) shouldEqual true
     }
 
     @Test
-    internal fun `Should check rule UGYLDIG_FNR_LENGDE, should NOT trigger rule`() {
-        ValidationRuleChain.UGYLDIG_FNR_LENGDE_PASIENT(
+    internal fun `Should check rule UGYLDIG_IDENT_LENGDE, should NOT trigger rule`() {
+        ValidationRuleChain.UGYLDIG_INNBYGGERIDENT_LENGDE(
             ruleData(dialogmelding, patientPersonNumber = "04030350265")
         ) shouldEqual false
     }
 
     @Test
-    internal fun `Should check rule UGYLDIG_FNR_PASIENT, should trigger rule`() {
-        ValidationRuleChain.UGYLDIG_FNR_PASIENT(
+    internal fun `Should check rule UGYLDIG_IDENT_PASIENT, should trigger rule`() {
+        ValidationRuleChain.UGYLDIG_INNBYGGERIDENT(
             ruleData(dialogmelding, patientPersonNumber = "30063104424")
         ) shouldEqual true
     }
 
     @Test
-    internal fun `Should check rule UGYLDIG_FNR, should NOT trigger rule`() {
-        ValidationRuleChain.UGYLDIG_FNR_PASIENT(
+    internal fun `Should check rule UGYLDIG_IDENT_PASIENT, invalid DNR should trigger rule`() {
+        ValidationRuleChain.UGYLDIG_INNBYGGERIDENT(
+            ruleData(dialogmelding, patientPersonNumber = "70063104424")
+        ) shouldEqual true
+    }
+
+    @Test
+    internal fun `Should check rule UGYLDIG_IDENT, should NOT trigger rule`() {
+        ValidationRuleChain.UGYLDIG_INNBYGGERIDENT(
             ruleData(dialogmelding, patientPersonNumber = "04030350265")
+        ) shouldEqual false
+    }
+
+    @Test
+    internal fun `Should check rule UGYLDIG_IDENT, valid DNR should NOT trigger rule`() {
+        ValidationRuleChain.UGYLDIG_INNBYGGERIDENT(
+            ruleData(dialogmelding, patientPersonNumber = "45088649080")
         ) shouldEqual false
     }
 
@@ -68,7 +82,7 @@ internal class ValidationRuleChainSpek {
 
     @Test
     internal fun `AVSENDER_FNR_ER_SAMME_SOM_PASIENT_FNR should trigger on rule`() {
-        ValidationRuleChain.AVSENDER_FNR_ER_SAMME_SOM_PASIENT_FNR(
+        ValidationRuleChain.AVSENDER_FNR_ER_SAMME_SOM_INNBYGGER_FNR(
             ruleData(dialogmelding, avsenderfnr = "30063104424", patientPersonNumber = "30063104424")
         ) shouldEqual true
     }
@@ -76,7 +90,7 @@ internal class ValidationRuleChainSpek {
     @Test
     internal fun `AVSENDER_FNR_ER_SAMME_SOM_PASIENT_FNR should not trigger on rule`() {
 
-        ValidationRuleChain.AVSENDER_FNR_ER_SAMME_SOM_PASIENT_FNR(
+        ValidationRuleChain.AVSENDER_FNR_ER_SAMME_SOM_INNBYGGER_FNR(
             ruleData(dialogmelding, avsenderfnr = "04030350265", patientPersonNumber = "04030350261")
         ) shouldEqual false
     }

--- a/src/test/resources/dialogmelding_dialog_notat_dnr.xml
+++ b/src/test/resources/dialogmelding_dialog_notat_dnr.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<EI_fellesformat xmlns="http://www.nav.no/xml/eiff/2/"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <MsgHead xmlns="http://www.kith.no/xmlstds/msghead/2006-05-24">
+        <MsgInfo>
+            <Type DN="Notat" V="DIALOG_NOTAT" />
+            <MIGversion>v1.2 2006-05-24</MIGversion>
+            <GenDate>2019-01-16T22:51:35.5317672+01:00</GenDate>
+            <MsgId>37340D30-FE14-42B5-985F-A8FF8FFA0CB5</MsgId>
+            <Ack DN="Ja" V="J" />
+            <Sender>
+                <Organisation>
+                    <OrganisationName>Kule helsetjenester AS</OrganisationName>
+                    <Ident>
+                        <Id>223456789</Id>
+                        <TypeId DN="Organisasjonsnummeret i Enhetsregister (Brønnøysund)" S="1.16.578.1.12.3.1.1.9051" V="ENH" />
+                    </Ident>
+                    <Ident>
+                        <Id>0123</Id>
+                        <TypeId DN="Identifikator fra Helsetjenesteenhetsregisteret (HER-id)" V="HER" S="1.23.456.7.89.1.2.3.4567.8912" />
+                    </Ident>
+                    <Address>
+                        <StreetAdr>Oppdiktet gate 203</StreetAdr>
+                        <PostalCode>1234</PostalCode>
+                        <City>Oslo</City>
+                    </Address>
+                    <Organisation/>
+                    <HealthcareProfessional>
+                        <FamilyName>Valda</FamilyName>
+                        <MiddleName>Fos</MiddleName>
+                        <GivenName>Inga</GivenName>
+                        <Ident>
+                            <Id>1234</Id>
+                            <TypeId DN="Identifikator fra Helsetjenesteenhetsregisteret" S="1.16.578.1.12.4.3.1.8116" V="HER" />
+                        </Ident>
+                        <Ident>
+                            <Id>1234567</Id>
+                            <TypeId DN="HPR-nummer" S="1.16.578.1.12.3.1.1.8116" V="HPR" />
+                        </Ident>
+                        <Ident>
+                            <Id>04030350265</Id>
+                            <TypeId DN="Fødselsnummer" V="FNR" S="6.87.654.3.21.9.8.7.6543.2198" />
+                        </Ident>
+                        <Ident>
+                            <Id>45069800525</Id>
+                            <TypeId DN="D-nummer" V="DNR" S="6.16.578.1.12.4.1.4.8116" />
+                        </Ident>
+                        <Address>
+                            <StreetAdr>Oppdiktet gate 9001</StreetAdr>
+                            <PostalCode>9998</PostalCode>
+                            <City>Oppdiktet</City>
+                        </Address>
+                        <TeleCom>
+                            <TeleAddress V="98765432" />
+                            <TypeTelecom DN="Hovedtelefon" />
+                        </TeleCom>
+                    </HealthcareProfessional>
+                </Organisation>
+            </Sender>
+            <Receiver>
+                <Organisation>
+                    <OrganisationName>NAV</OrganisationName>
+                    <Ident>
+                        <Id>889640782</Id>
+                        <TypeId DN="Organisasjonsnummeret i Enhetsregister (Brønnøysund)" S="2.16.578.1.12.4.1.1.9051" V="ENH" />
+                    </Ident>
+                    <Ident>
+                        <Id>79768</Id>
+                        <TypeId DN="Identifikator fra Helsetjenesteenhetsregisteret (HER-id)" S="2.16.578.1.12.4.1.1.9051" V="HER" />
+                    </Ident>
+                </Organisation>
+            </Receiver>
+            <Patient>
+                <FamilyName>Test</FamilyName>
+                <GivenName>Etternavn</GivenName>
+                <DateOfBirth>1991-12-4</DateOfBirth>
+                <Sex DN="Mann" V="1" />
+                <Ident>
+                    <Id>45088649080</Id>
+                    <TypeId DN="D-nummer" V="DNR" S="6.16.578.1.12.4.1.4.8116" />
+                </Ident>
+                <Address>
+                    <Type DN="Postadresse" V="PST" />
+                    <StreetAdr>Sannergata 2</StreetAdr>
+                    <PostalCode>0655</PostalCode>
+                    <City>OSLO</City>
+                    <County DN="OSLO" V="0712" />
+                </Address>
+            </Patient>
+        </MsgInfo>
+        <Document>
+            <RefDoc>
+                <IssueDate V="2019-01-16T21:57:36" />
+                <MsgType DN="XML-instans" V="XML" />
+                <Content>
+                    <Dialogmelding xmlns="http://www.kith.no/xmlstds/dialog/2006-10-11"
+                                   xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                        <Notat>
+                            <TemaKodet DN="Henvendelse om sykefraværsoppfølging" S="2.16.578.1.12.4.1.1.8128" V="1" />
+                            <TekstNotatInnhold xsi:type="xsd:string">Hei,Det gjelder pas. Sender som vedlegg epikrisen</TekstNotatInnhold>
+                            <DokIdNotat>A1578B81-0042-453B-8527-6CF182BDA6C7</DokIdNotat>
+                            <DatoNotat>2019-01-16</DatoNotat>
+                            <Foresporsel>
+                                <TypeForesp DN="Påminnelse forespørsel om pasient" S="2.16.578.1.12.4.1.1.8129" V="2"/>
+                                <Sporsmal>
+                                    The Foresporsel tag including content is currently ignored if the dialogmelding is
+                                    of type dialog_notat/henvendelse fra lege. This is necessary because EPJs were
+                                    allowed to send incorrect XML to previous system EIA.
+                                </Sporsmal>
+                            </Foresporsel>
+                        </Notat>
+                    </Dialogmelding>
+                </Content>
+            </RefDoc>
+        </Document>
+    </MsgHead>
+    <MottakenhetBlokk avsender="12312341" avsenderFnrFraDigSignatur="1231124124" avsenderRef="SERIALNUMBER=996871045, CN=LEGEHUSET NOVA DA, O=LEGEHUSET NOVA DA, C=NO" ebAction="Henvendelse" ebRole="Sykmelder" ebService="HenvendelseFraLege" ebXMLSamtaleId="615356d4-f5e6-4138-a868-bbb63bd6195d" ediLoggId="1901162157lege21826.1" herIdentifikator="" meldingsType="xml" mottattDatotid="2019-01-16T21:57:43" partnerReferanse="13123" />
+</EI_fellesformat>


### PR DESCRIPTION
Hvis vi ikke finner fnr i meldingen, let etter dnr.
Hvis ingen finnes, håndter likt som tidligere når man ikke fant fnr.
Dnr brukes på samme måte som fnr.
Endre navn på ValidationRules, for å reflektere at det kan være mer enn bare fnr.
Legg til test i CreateArenaDialogNotatTest.