### PR TITLE
Remove redundant buildscript dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,17 +47,6 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "10.2.0"
 }
 
-buildscript {
-    dependencies {
-        classpath("javax.xml.bind:jaxb-api:2.4.0-b180830.0359")
-        classpath("org.glassfish.jaxb:jaxb-runtime:2.4.0-b180830.0438")
-        classpath("com.sun.activation:javax.activation:1.2.0")
-        classpath("com.sun.xml.ws:jaxws-tools:2.3.1") {
-            exclude(group = "com.sun.xml.ws", module = "policy")
-        }
-    }
-}
-
 val githubUser: String by project
 val githubPassword: String by project
 


### PR DESCRIPTION
These class dependecies are included in the list of dependencies. Also loading them in a buildscript is redundant.