### PR TITLE
Hopp over journalføring ved manglende aktoerId

### DIFF
--- a/src/main/kotlin/no/nav/syfo/handlestatus/HandleStatusInvalid.kt
+++ b/src/main/kotlin/no/nav/syfo/handlestatus/HandleStatusInvalid.kt
@@ -4,8 +4,7 @@ import net.logstash.logback.argument.StructuredArguments.fields
 import no.nav.helse.apprecV1.XMLCV
 import no.nav.helse.eiFellesformat2.XMLEIFellesformat
 import no.nav.syfo.Environment
-import no.nav.syfo.apprec.ApprecStatus
-import no.nav.syfo.apprec.toApprecCV
+import no.nav.syfo.apprec.*
 import no.nav.syfo.client.IdentInfoResult
 import no.nav.syfo.db.DatabaseInterface
 import no.nav.syfo.logger
@@ -42,14 +41,18 @@ suspend fun handleStatusINVALID(
     sha256String: String,
 ) {
 
-    journalService.onJournalRequest(
-        receivedDialogmelding,
-        validationResult,
-        vedleggListe,
-        loggingMeta,
-        pasientNavn,
-        navnSignerendeLege
-    )
+    if (receivedDialogmelding.pasientAktoerId != null) {
+        journalService.onJournalRequest(
+            receivedDialogmelding,
+            validationResult,
+            vedleggListe,
+            loggingMeta,
+            pasientNavn,
+            navnSignerendeLege
+        )
+    } else {
+        logger.info("Lagrer ikke i Joark pga av manglende AktoerId for pasient {}", fields(loggingMeta))
+    }
 
     handleRecivedMessage(receivedDialogmelding, validationResult, sha256String, loggingMeta, database)
 

--- a/src/test/kotlin/no/nav/syfo/mock/DokarkivMock.kt
+++ b/src/test/kotlin/no/nav/syfo/mock/DokarkivMock.kt
@@ -7,6 +7,7 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
+import no.nav.syfo.UserConstants
 import no.nav.syfo.client.installContentNegotiation
 import no.nav.syfo.getRandomPort
 import no.nav.syfo.model.JournalpostRequest
@@ -39,7 +40,11 @@ class DokarkivMock {
             routing {
                 post {
                     val journalpostRequest = call.receive<JournalpostRequest>()
-                    call.respond(journalpostResponse)
+                    if (journalpostRequest.bruker!!.id != UserConstants.PATIENT_FNR_NO_AKTOER_ID) {
+                        call.respond(journalpostResponse)
+                    } else {
+                        call.respond(HttpStatusCode.InternalServerError)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Journalføring feiler for pasienter der vi ikke finner aktørid, så må hoppe over journalføring for slike meldinger.