### PR TITLE
Håndtere at tekstnotat mangler

### DIFF
--- a/src/main/kotlin/no/nav/syfo/model/DialogmeldingMapper.kt
+++ b/src/main/kotlin/no/nav/syfo/model/DialogmeldingMapper.kt
@@ -37,7 +37,7 @@ fun XMLNotat.toHenvendelseFraLegeHenvendelse(): HenvendelseFraLegeHenvendelse {
 
     return HenvendelseFraLegeHenvendelse(
         temaKode = temaKodet.toTemaKode(),
-        tekstNotatInnhold = tekstNotatInnhold.toString(),
+        tekstNotatInnhold = tekstNotatInnhold?.toString() ?: "",
         dokIdNotat = dokIdNotat,
         foresporsel = null, // Ignore because EPJ send incorrect data and we don't use it
         rollerRelatertNotat = if (rollerRelatertNotat.isNotEmpty()) {
@@ -92,7 +92,7 @@ fun XMLNotat.toForesporselFraSaksbehandlerForesporselSvar(): ForesporselFraSaksb
 
     return ForesporselFraSaksbehandlerForesporselSvar(
         temaKode = temaKodet.toTemaKode(),
-        tekstNotatInnhold = tekstNotatInnhold.toString(),
+        tekstNotatInnhold = tekstNotatInnhold?.toString() ?: "",
         dokIdNotat = dokIdNotat,
         datoNotat = datoNotat?.toGregorianCalendar()?.toZonedDateTime()?.toLocalDateTime()
     )

--- a/src/test/kotlin/no/nav/syfo/dialogmelding/BlockingApplicationRunnerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmelding/BlockingApplicationRunnerSpek.kt
@@ -65,6 +65,19 @@ class BlockingApplicationRunnerSpek : Spek({
                     verify(exactly = 1) { arenaProducer.send(any()) }
                     verify(exactly = 1) { dialogmeldingProducer.sendDialogmelding(any(), any(), any(), any()) }
                 }
+                it("Prosesserer innkommet melding (tekst i notatinnhold mangler)") {
+                    val fellesformat =
+                        getFileAsString("src/test/resources/dialogmelding_dialog_notat.xml")
+                            .replace("<TekstNotatInnhold xsi:type=\"xsd:string\">Hei,Det gjelder pas. Sender som vedlegg epikrisen</TekstNotatInnhold>", "")
+                    every { incomingMessage.text } returns(fellesformat)
+                    runBlocking {
+                        blockingApplicationRunner.processMessageHandleException(incomingMessage)
+                    }
+                    verify(exactly = 1) { receiptProducer.send(any()) }
+                    verify(exactly = 0) { backoutProducer.send(any()) }
+                    verify(exactly = 0) { arenaProducer.send(any()) }
+                    verify(exactly = 0) { dialogmeldingProducer.sendDialogmelding(any(), any(), any(), any()) }
+                }
                 it("Prosesserer innkommet melding (duplikat)") {
                     val fellesformat =
                         getFileAsString("src/test/resources/dialogmelding_dialog_notat.xml")


### PR DESCRIPTION
Problemet oppstod pga av at valideringen er flyttet litt lengre ned i løypa, så da ble det noen nullpointer-feil (i stedet for at meldingene feilet kontrollert med negativ apprec).