### PR TITLE
Increase socket timeout to 1 minute for Dokarkiv requests

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/BlockingApplicationRunner.kt
+++ b/src/main/kotlin/no/nav/syfo/application/BlockingApplicationRunner.kt
@@ -75,7 +75,7 @@ class BlockingApplicationRunner(
         azureAdV2Client = azureAdV2Client,
         dokArkivClientId = env.dokArkivClientId,
         url = env.dokArkivUrl,
-        httpClient = httpClientWithProxy,
+        httpClient = httpClientWithTimeout,
     )
 
     val syfohelsenettproxyClient = SyfohelsenettproxyClient(

--- a/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
+++ b/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.client
 import io.ktor.application.*
 import io.ktor.client.*
 import io.ktor.client.engine.apache.*
+import io.ktor.client.features.*
 import io.ktor.client.features.json.*
 import io.ktor.features.*
 import io.ktor.jackson.*
@@ -18,6 +19,20 @@ val config: HttpClientConfig<ApacheEngineConfig>.() -> Unit = {
     expectSuccess = false
 }
 
+val httpClientWithProxyAndTimeout: HttpClientConfig<ApacheEngineConfig>.() -> Unit = {
+    install(JsonFeature) {
+        serializer = JacksonSerializer(configuredJacksonMapper())
+    }
+    install(HttpTimeout) {
+        socketTimeoutMillis = 60000
+    }
+    engine {
+        customizeClient {
+            setRoutePlanner(SystemDefaultRoutePlanner(ProxySelector.getDefault()))
+        }
+    }
+}
+
 val proxyConfig: HttpClientConfig<ApacheEngineConfig>.() -> Unit = {
     install(JsonFeature) {
         serializer = JacksonSerializer(configuredJacksonMapper())
@@ -30,6 +45,7 @@ val proxyConfig: HttpClientConfig<ApacheEngineConfig>.() -> Unit = {
 }
 
 val httpClient = HttpClient(Apache, config)
+val httpClientWithTimeout = HttpClient(Apache, httpClientWithProxyAndTimeout)
 val httpClientWithProxy = HttpClient(Apache, proxyConfig)
 
 fun Application.installContentNegotiation() {


### PR DESCRIPTION
Let dialogmeldinger with large attachments pass without Joark timing out.