### PR TITLE
Use correct values in Apprec error, according to spec

### DIFF
--- a/src/main/kotlin/no/nav/syfo/apprec/ApprecMapper.kt
+++ b/src/main/kotlin/no/nav/syfo/apprec/ApprecMapper.kt
@@ -124,6 +124,6 @@ fun RuleInfo.toApprecCV(): AppRecCV {
 
 fun createApprecError(textToTreater: String): AppRecCV = AppRecCV().apply {
     dn = textToTreater
-    v = "2.16.578.1.12.4.1.1.8221"
-    s = "X99"
+    v = "X99"
+    s = "2.16.578.1.12.4.1.1.8221"
 }

--- a/src/main/kotlin/no/nav/syfo/handlestatus/HandleStatusInvalid.kt
+++ b/src/main/kotlin/no/nav/syfo/handlestatus/HandleStatusInvalid.kt
@@ -204,6 +204,6 @@ fun handleInvalidDialogMeldingKodeverk(
 
 fun createApprecError(errorText: String): XMLCV = XMLCV().apply {
     dn = errorText
-    v = "2.16.578.1.12.4.1.1.8221"
-    s = "X99"
+    v = "X99"
+    s = "2.16.578.1.12.4.1.1.8221"
 }


### PR DESCRIPTION
This is the same error as team sykmelding has discovered and corrected.

https://github.com/navikt/syfosmapprec/commit/3d89361a8b0326936d01ec8d5ac1f341610c5982