### PR TITLE
Log response from emottak subscription

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/services/EmottakSubscriptionService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/services/EmottakSubscriptionService.kt
@@ -29,13 +29,14 @@ suspend fun startSubscription(
         retryIntervals = arrayOf(500L, 1000L, 3000L, 5000L, 10000L),
         legalExceptions = *arrayOf(IOException::class, WstxException::class)
     ) {
-        subscriptionEmottak.startSubscription(
+        val response = subscriptionEmottak.startSubscription(
             StartSubscriptionRequest().apply {
                 key = samhandlerPraksis.tss_ident
                 data = convertSenderToBase64(msgHead.msgInfo.sender)
                 partnerid = receiverBlock.partnerReferanse.toInt()
             }
         )
+        logger.info("Started emottak subscription for ${samhandlerPraksis.tss_ident}, got response: ${response.status} (key: ${response.key}, description: ${response.description})")
     }
 }
 


### PR DESCRIPTION
Vil gjerne kjøre padm2 med denne logging først (for å verifisere at responsene vi får når subscription kjører i isproxy er tilsvarende det vi får fra padm2 i utgangspunktet).

Dvs vil kjøre med denne tilpasningen en liten stund før https://github.com/navikt/padm2/pull/104 merges,