### PR TITLE
Return ValidationResult object from initial validation

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/DialogmeldingProcessor.kt
+++ b/src/main/kotlin/no/nav/syfo/application/DialogmeldingProcessor.kt
@@ -251,7 +251,7 @@ class DialogmeldingProcessor(
         dialogmeldingXml: XMLDialogmelding,
         receivedDialogmelding: ReceivedDialogmelding,
     ): ValidationResult {
-        val initialValidationResult =
+        val initialValidationResult: ValidationResult? =
             if (dialogmeldingDokumentWithShaExists(receivedDialogmelding.dialogmelding.id, sha256String, database)) {
                 val tidMottattOpprinneligMelding = database.hentMottattTidspunkt(sha256String)
                 handleDuplicateDialogmeldingContent(
@@ -270,17 +270,10 @@ class DialogmeldingProcessor(
             } else {
                 null
             }
-        return if (initialValidationResult != null) {
-            ValidationResult(
-                status = Status.INVALID,
-                apprecMessage = initialValidationResult,
-                ruleHits = emptyList(),
-            )
-        } else {
-            padm2ReglerService.executeRuleChains(
-                receivedDialogmelding = receivedDialogmelding,
-            )
-        }
+
+        return initialValidationResult ?: padm2ReglerService.executeRuleChains(
+            receivedDialogmelding = receivedDialogmelding,
+        )
     }
 
     suspend fun findSamhandlerpraksis(

--- a/src/main/kotlin/no/nav/syfo/model/ValidationResult.kt
+++ b/src/main/kotlin/no/nav/syfo/model/ValidationResult.kt
@@ -2,7 +2,6 @@ package no.nav.syfo.model
 
 data class ValidationResult(
     val status: Status,
-    val apprecMessage: String? = null,
     val ruleHits: List<RuleInfo>
 )
 


### PR DESCRIPTION
Da får vi med begrunnelse for avvisningen i pdfen som journalføres.
Fjern apprecMessage-feltet fra ValidationResult, siden det ikke lenger brukes.