### PR TITLE
Bugfix: improve handling of invalid kodeverk

### DIFF
--- a/src/main/kotlin/no/nav/syfo/model/DialogmeldingMapper.kt
+++ b/src/main/kotlin/no/nav/syfo/model/DialogmeldingMapper.kt
@@ -33,69 +33,77 @@ fun XMLDialogmelding.toDialogmelding(
 
 )
 
-fun XMLNotat.toHenvendelseFraLegeHenvendelse(): HenvendelseFraLegeHenvendelse {
-
-    return HenvendelseFraLegeHenvendelse(
-        temaKode = temaKodet.toTemaKode(),
-        tekstNotatInnhold = tekstNotatInnhold?.toString() ?: "",
-        dokIdNotat = dokIdNotat,
-        foresporsel = null, // Ignore because EPJ send incorrect data and we don't use it
-        rollerRelatertNotat = if (rollerRelatertNotat.isNotEmpty()) {
-            RollerRelatertNotat(
-                rolleNotat = if (rollerRelatertNotat.firstOrNull()?.person != null) {
-                    RolleNotat(
-                        rollerRelatertNotat.first().rolleNotat.s,
-                        rollerRelatertNotat.first().rolleNotat.v
-                    )
-                } else {
-                    null
-                },
-                person = if (rollerRelatertNotat.firstOrNull()?.person != null) {
-                    Person(rollerRelatertNotat.first().person.givenName, rollerRelatertNotat.first().person.familyName)
-                } else {
-                    null
-                },
-                helsepersonell = if (rollerRelatertNotat.firstOrNull()?.healthcareProfessional != null) {
-                    Helsepersonell(
-                        rollerRelatertNotat.first().healthcareProfessional.givenName,
-                        rollerRelatertNotat.first().healthcareProfessional.familyName
-                    )
-                } else {
-                    null
-                }
-            )
-        } else {
-            null
-        }
-    )
+fun XMLNotat.toHenvendelseFraLegeHenvendelse(): HenvendelseFraLegeHenvendelse? {
+    return temaKodet.toTemaKode()?.let { it ->
+        HenvendelseFraLegeHenvendelse(
+            temaKode = it,
+            tekstNotatInnhold = tekstNotatInnhold?.toString() ?: "",
+            dokIdNotat = dokIdNotat,
+            foresporsel = null, // Ignore because EPJ send incorrect data and we don't use it
+            rollerRelatertNotat = if (rollerRelatertNotat.isNotEmpty()) {
+                RollerRelatertNotat(
+                    rolleNotat = if (rollerRelatertNotat.firstOrNull()?.person != null) {
+                        RolleNotat(
+                            rollerRelatertNotat.first().rolleNotat.s,
+                            rollerRelatertNotat.first().rolleNotat.v
+                        )
+                    } else {
+                        null
+                    },
+                    person = if (rollerRelatertNotat.firstOrNull()?.person != null) {
+                        Person(
+                            rollerRelatertNotat.first().person.givenName,
+                            rollerRelatertNotat.first().person.familyName
+                        )
+                    } else {
+                        null
+                    },
+                    helsepersonell = if (rollerRelatertNotat.firstOrNull()?.healthcareProfessional != null) {
+                        Helsepersonell(
+                            rollerRelatertNotat.first().healthcareProfessional.givenName,
+                            rollerRelatertNotat.first().healthcareProfessional.familyName
+                        )
+                    } else {
+                        null
+                    }
+                )
+            } else {
+                null
+            }
+        )
+    }
 }
 
-fun CV.toTemaKode(): TemaKode {
-    return findDialogmeldingKodeverk(s, v)!!.toTypeMelding()
+fun CV.toTemaKode(): TemaKode? {
+    return findDialogmeldingKodeverk(s, v)?.toTypeMelding()
 }
 
 fun DialogmeldingKodeverk.toTypeMelding(): TemaKode {
     return TemaKode(kodeverkOID, dn, v, arenaNotatKategori, arenaNotatKode, arenaNotatTittel)
 }
 
-fun XMLNotat.toInnkallingMoterespons(): InnkallingMoterespons {
+fun XMLNotat.toInnkallingMoterespons(): InnkallingMoterespons? {
 
-    return InnkallingMoterespons(
-        temaKode = temaKodet.toTemaKode(),
-        tekstNotatInnhold = tekstNotatInnhold?.toString(),
-        dokIdNotat = dokIdNotat,
-        foresporsel = foresporsel?.toForesporsel()
-    )
+    return temaKodet.toTemaKode()?.let { it ->
+        InnkallingMoterespons(
+            temaKode = it,
+            tekstNotatInnhold = tekstNotatInnhold?.toString(),
+            dokIdNotat = dokIdNotat,
+            foresporsel = foresporsel?.toForesporsel()
+        )
+    }
 }
 
-fun XMLNotat.toForesporselFraSaksbehandlerForesporselSvar(): ForesporselFraSaksbehandlerForesporselSvar {
+fun XMLNotat.toForesporselFraSaksbehandlerForesporselSvar(): ForesporselFraSaksbehandlerForesporselSvar? {
 
-    return ForesporselFraSaksbehandlerForesporselSvar(
-        temaKode = temaKodet.toTemaKode(),
-        tekstNotatInnhold = tekstNotatInnhold?.toString() ?: "",
-        dokIdNotat = dokIdNotat,
-        datoNotat = datoNotat?.toGregorianCalendar()?.toZonedDateTime()?.toLocalDateTime()
-    )
+    return temaKodet.toTemaKode()?.let { it ->
+        ForesporselFraSaksbehandlerForesporselSvar(
+            temaKode = it,
+            tekstNotatInnhold = tekstNotatInnhold?.toString() ?: "",
+            dokIdNotat = dokIdNotat,
+            datoNotat = datoNotat?.toGregorianCalendar()?.toZonedDateTime()?.toLocalDateTime()
+        )
+    }
 }
 
 fun XMLForesporsel.toForesporsel(): Foresporsel {

--- a/src/test/kotlin/no/nav/syfo/dialogmelding/BlockingApplicationRunnerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmelding/BlockingApplicationRunnerSpek.kt
@@ -104,6 +104,18 @@ class BlockingApplicationRunnerSpek : Spek({
                     verify(exactly = 0) { mqSender.sendArena(any()) }
                     verify(exactly = 0) { dialogmeldingProducer.sendDialogmelding(any(), any(), any(), any()) }
                 }
+                it("Prosesserer innkommet melding (ugyldig kodeverk)") {
+                    val fellesformat =
+                        getFileAsString("src/test/resources/dialogmelding_dialog_svar_foresporsel_om_pasient_invalid.xml")
+                    every { incomingMessage.text } returns(fellesformat)
+                    runBlocking {
+                        blockingApplicationRunner.processMessageHandleException(incomingMessage)
+                    }
+                    verify(exactly = 1) { mqSender.sendReceipt(any()) }
+                    verify(exactly = 0) { mqSender.sendBackout(any()) }
+                    verify(exactly = 0) { mqSender.sendArena(any()) }
+                    verify(exactly = 0) { dialogmeldingProducer.sendDialogmelding(any(), any(), any(), any()) }
+                }
                 it("Prosesserer innkommet melding (duplikat)") {
                     val fellesformat =
                         getFileAsString("src/test/resources/dialogmelding_dialog_notat.xml")

--- a/src/test/resources/dialogmelding_dialog_svar_foresporsel_om_pasient_invalid.xml
+++ b/src/test/resources/dialogmelding_dialog_svar_foresporsel_om_pasient_invalid.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EI_fellesformat xmlns="http://www.nav.no/xml/eiff/2/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <MsgHead xmlns="http://www.kith.no/xmlstds/msghead/2006-05-24" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <MsgInfo>
+            <Type DN="Svar på forespørsel" V="DIALOG_SVAR"/>
+            <MIGversion>v1.2 2006-05-24</MIGversion>
+            <GenDate>2020-09-30T18:00:31.4764563+02:00</GenDate>
+            <MsgId>b62016eb-6c2d-417a-8ecc-157b3c5ee2ca</MsgId>
+            <Ack DN="Ja" V="J"/>
+            <Sender>
+                <Organisation>
+                    <OrganisationName>Kule helsetjenester AS</OrganisationName>
+                    <Ident>
+                        <Id>223456789</Id>
+                        <TypeId DN="Organisasjonsnummeret i Enhetsregister" S="2.16.578.1.12.4.1.1.9051" V="ENH"/>
+                    </Ident>
+                    <Ident>
+                        <Id>0123</Id>
+                        <TypeId DN="HER-id" S="2.16.578.1.12.4.1.1.9051" V="HER"/>
+                    </Ident>
+                    <Address>
+                        <Type DN="Postadresse" V="PST"/>
+                        <StreetAdr>Oppdiktet gate 203</StreetAdr>
+                        <PostalCode>1234</PostalCode>
+                        <City>Oslo</City>
+                        <County DN="Oslo" V="0712"/>
+                        <Country DN="Norge" V="NO"/>
+                    </Address>
+                    <TeleCom>
+                        <TypeTelecom DN="Arbeidsplass" V="WP"/>
+                        <TeleAddress V="tel:11223344"/>
+                    </TeleCom>
+                    <HealthcareProfessional>
+                        <TypeHealthcareProfessional DN="Lege" V="LE"/>
+                        <FamilyName>Valda</FamilyName>
+                        <MiddleName>Fos</MiddleName>
+                        <GivenName>Inga</GivenName>
+                        <Ident>
+                            <Id>1234567</Id>
+                            <TypeId DN="HPR-nummer" S="2.16.578.1.12.4.1.1.8116" V="HPR"/>
+                        </Ident>
+                        <Ident>
+                            <Id>1234</Id>
+                            <TypeId DN="HER-id" S="2.16.578.1.12.4.1.1.8116" V="HER"/>
+                        </Ident>
+                    </HealthcareProfessional>
+                </Organisation>
+            </Sender>
+            <Receiver>
+                <Organisation>
+                    <OrganisationName>NAV</OrganisationName>
+                    <Ident>
+                        <Id>889640782</Id>
+                        <TypeId DN="Organisasjonsnummeret i Enhetsregister" S="2.16.578.1.12.4.1.1.9051" V="ENH"/>
+                    </Ident>
+                    <Ident>
+                        <Id>79768</Id>
+                        <TypeId DN="HER-id" S="2.16.578.1.12.4.1.1.9051" V="HER"/>
+                    </Ident>
+                    <Organisation>
+                        <OrganisationName>NAV Drammen</OrganisationName>
+                        <Ident>
+                            <Id>0602</Id>
+                            <TypeId DN="Lokal identifikator for institusjoner" S="2.16.578.1.12.4.1.1.9051" V="LIN"/>
+                        </Ident>
+                    </Organisation>
+                </Organisation>
+            </Receiver>
+            <Patient>
+                <FamilyName>Test</FamilyName>
+                <GivenName>Etternavn</GivenName>
+                <Ident>
+                    <Id>01010142365</Id>
+                    <TypeId DN="Fødselsnummer" S="2.16.578.1.12.4.1.1.8116" V="FNR"/>
+                </Ident>
+                <Address>
+                    <Type DN="Folkeregisteradresse" V="HP"/>
+                    <StreetAdr>Sannergata 2</StreetAdr>
+                    <PostalCode>0655</PostalCode>
+                    <City>OSLO</City>
+                    <County DN="OSLO" V="0712" />
+                    <Country DN="Norge" V="NO"/>
+                </Address>
+                <TeleCom>
+                    <TypeTelecom DN="Mobiltelefon" V="MC"/>
+                    <TeleAddress V="tel:11223344"/>
+                </TeleCom>
+                <TeleCom>
+                    <TypeTelecom DN="Hjemme" V="H"/>
+                    <TeleAddress V="tel:44332211"/>
+                </TeleCom>
+            </Patient>
+        </MsgInfo>
+        <Document>
+            <RefDoc>
+                <IssueDate V="2020-09-30T18:00:31"/>
+                <MsgType DN="XML-instans" V="XML"/>
+                <Content>
+                    <Dialogmelding xmlns="http://www.kith.no/xmlstds/dialog/2006-10-11" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                        <Notat>
+                            <TemaKodet DN="Svar på forespørsel" S="2.16.578.1.12.4.1.1.9069" V="1"/>
+                            <TekstNotatInnhold xsi:type="xsd:string">Pasieten har masse info her</TekstNotatInnhold>
+                            <DokIdNotat>OD1812186729156</DokIdNotat>
+                            <Foresporsel>
+                                <TypeForesp DN="Påminnelse forespørsel om pasient" S="2.16.578.1.12.4.1.1.8129" V="2"/>
+                                <Sporsmal>
+                                    Påminnelse
+                                    Test Etternavn
+                                    Vi viser til tidligere forespørsel angående din pasient.
+                                    Vi kan ikke se å ha mottatt svar på vår henvendelse og ber om at vår anmodning om opplysninger angående
+                                    ovennevnte pasient besvares snarest.
+                                    Hvis opplysningene er sendt oss i løpet av de siste dagene, kan du se bort fra dette brevet.
+                                    Med hilsen
+                                    NAV
+                                    Jon Person
+                                </Sporsmal>
+                                <DokIdForesp>OD1812186729156</DokIdForesp>
+                                <RollerRelatertNotat>
+                                    <RolleNotat S="2.16.578.1.12.4.1.1.9057" V="1"/>
+                                    <Person>
+                                        <GivenName>Jon</GivenName>
+                                        <FamilyName>Person</FamilyName>
+                                    </Person>
+                                </RollerRelatertNotat>
+                            </Foresporsel>
+                        </Notat>
+                    </Dialogmelding>
+                </Content>
+            </RefDoc>
+        </Document>
+    </MsgHead>
+    <MottakenhetBlokk avsender="1231341" avsenderFnrFraDigSignatur="21312341414" avsenderRef="SERIALNUMBER=988024031, CN=Sentrum Legekontor, O=SENTRUM-LEGEKONTOR ANS, C=NO" ebAction="ForesporselSvar" ebRole="Sykmelder" ebService="ForesporselFraSaksbehandler" ebXMLSamtaleId="47822e21-0151-4fb1-a223-99f0aba5d51b" ediLoggId="FiktivTestdata0001" herIdentifikator="" meldingsType="xml" mottattDatotid="2020-09-30T18:02:10" partnerReferanse="12049"/>
+</EI_fellesformat>


### PR DESCRIPTION
Noen varianter av ugyldig kodeverk ender i NullPointerException slik at meldingene havner på backout (og det genereres ikke apprec). 

Denne PR'en forbedrer dette slik at de lagres i databasen (som andre meldinger med ugyldig kodeverk), og får negativ apprec.