### PR TITLE
Bugfix: vedlegg with mimetype image/jpg

### DIFF
--- a/src/main/kotlin/no/nav/syfo/util/ExtractFromFellesFormat.kt
+++ b/src/main/kotlin/no/nav/syfo/util/ExtractFromFellesFormat.kt
@@ -17,7 +17,7 @@ fun extractVedlegg(fellesformat: XMLEIFellesformat) = fellesformat.get<XMLMsgHea
 
 fun XMLDocument.isVedlegg(): Boolean {
     return this.refDoc.msgType.v == "A" &&
-        listOf("application/pdf", "image/tiff", "image/png", "image/jpeg").contains(this.refDoc.mimeType)
+        listOf("application/pdf", "image/tiff", "image/png", "image/jpeg", "image/jpg").contains(this.refDoc.mimeType)
 }
 
 fun extractOrganisationNumberFromSender(fellesformat: XMLEIFellesformat): XMLIdent? =


### PR DESCRIPTION
Vi fikk en dialogmelding som feilet i dag siden den ikke kunne legges på Kafka-topic fordi meldingen er for stor. 

Viser seg at årsaken er vedlegg med mimetype image/jpg som ikke ble oppdaget og fjernet før padm2 forsøkte å legge på Kafka-topic.