### PR TITLE
httpClient expects success

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/DokArkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/DokArkivClient.kt
@@ -45,7 +45,7 @@ class DokArkivClient(
             when (response.status) {
                 HttpStatusCode.OK -> response.body()
                 HttpStatusCode.Created -> response.body()
-                else -> throw RuntimeException("Http status: ${response.status} Content: ${response.bodyAsText()}")
+                else -> throw RuntimeException("Http status: ${response.status} Content: ${response.bodyAsChannel()}")
             }
         } catch (e: Exception) {
             logger.warn("Oppretting av journalpost feilet: ${e.message}, {}", fields(loggingMeta))

--- a/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
+++ b/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
@@ -20,6 +20,7 @@ val httpClientWithProxyAndTimeout: HttpClientConfig<ApacheEngineConfig>.() -> Un
     install(ContentNegotiation) {
         jackson { configure() }
     }
+    expectSuccess = true
     install(HttpTimeout) {
         socketTimeoutMillis = 60000
     }
@@ -34,6 +35,7 @@ val proxyConfig: HttpClientConfig<ApacheEngineConfig>.() -> Unit = {
     install(ContentNegotiation) {
         jackson { configure() }
     }
+    expectSuccess = true
     engine {
         customizeClient {
             setRoutePlanner(SystemDefaultRoutePlanner(ProxySelector.getDefault()))

--- a/src/main/kotlin/no/nav/syfo/client/KuhrSarClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/KuhrSarClient.kt
@@ -44,7 +44,7 @@ class KuhrSarClient(
         }
         when (response.status) {
             HttpStatusCode.OK -> response.body<KuhrsarResponse>().tssId
-            else -> throw IOException("Vi fikk en uventet feil fra kuhrSar, prøver på nytt! ${response.bodyAsText()}")
+            else -> throw IOException("Vi fikk en uventet feil fra kuhrSar, prøver på nytt! ${response.bodyAsChannel()}")
         }
     }
 }

--- a/src/test/kotlin/no/nav/syfo/client/DokArkivClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/DokArkivClientTest.kt
@@ -56,6 +56,7 @@ internal class DokArkivClientTest {
                     configure()
                 }
             }
+            expectSuccess = true
             engine {
                 addHandler {
                     val responseHeaders = headersOf("Content-Type", ContentType.Application.Json.toString())


### PR DESCRIPTION
For at httpClient skal oppføre seg som før - ref: https://ktor.io/docs/migrating-2.html#response-validation
Endret samtidig til `response.bodyAsChannel` der hvor vi brukte `response.content` før oppgradering.