### PR TITLE
Handle invalid hprnr

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/DialogmeldingProcessor.kt
+++ b/src/main/kotlin/no/nav/syfo/application/DialogmeldingProcessor.kt
@@ -204,7 +204,7 @@ class DialogmeldingProcessor(
         val legekontorHerId = extractOrganisationHerNumberFromSender(fellesformat)?.id
         val dialogmeldingXml = extractDialogmelding(fellesformat)
         val dialogmeldingType = findDialogmeldingType(receiverBlock.ebService, receiverBlock.ebAction)
-        val legeHpr = extractLegeHpr(fellesformat)
+        val legeHpr = extractLegeHpr(dialogmeldingId, fellesformat)
         val behandlerNavn = extractBehandlerNavn(fellesformat)
         val behandlerIdent = extractIdentFromBehandler(fellesformat)
         val innbyggerIdent = extractInnbyggerident(fellesformat)

--- a/src/main/kotlin/no/nav/syfo/client/DokArkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/DokArkivClient.kt
@@ -176,11 +176,10 @@ private fun createAvsenderMottaker(
     avsenderFnr: String,
     avsenderHpr: String?,
     dialogmelding: Dialogmelding,
-): AvsenderMottaker {
-    if (avsenderHpr != null) {
-        return createAvsenderMottakerValidHpr(avsenderHpr, dialogmelding)
-    }
-    return when (validatePersonAndDNumber(avsenderFnr)) {
+) = if (avsenderHpr != null) {
+    createAvsenderMottakerValidHpr(avsenderHpr, dialogmelding)
+} else {
+    when (validatePersonAndDNumber(avsenderFnr)) {
         true -> createAvsenderMottakerValidFnr(avsenderFnr, dialogmelding)
         else -> createAvsenderMottakerNotValidFnr(dialogmelding)
     }

--- a/src/main/kotlin/no/nav/syfo/util/ExtractFromFellesFormat.kt
+++ b/src/main/kotlin/no/nav/syfo/util/ExtractFromFellesFormat.kt
@@ -34,11 +34,14 @@ fun extractOrganisationHerNumberFromSender(fellesformat: XMLEIFellesformat): XML
 fun extractSenderOrganisationName(fellesformat: XMLEIFellesformat): String =
     fellesformat.get<XMLMsgHead>().msgInfo.sender.organisation?.organisationName ?: ""
 
-fun extractLegeHpr(fellesformat: XMLEIFellesformat): String? {
+fun extractLegeHpr(dialogmeldingId: String, fellesformat: XMLEIFellesformat): String? {
     val hpr = fellesformat.get<XMLMsgHead>().msgInfo.sender.organisation?.healthcareProfessional?.ident?.find {
         it.typeId.v == "HPR"
     }?.id
-    return if (isValidHpr(hpr)) hpr else null
+    return if (isValidHpr(hpr)) hpr else {
+        logger.warn("Invalid hpr, ignoring. Dialogmeldingid: $dialogmeldingId")
+        null
+    }
 }
 
 private fun isValidHpr(hprNr: String?) =

--- a/src/main/kotlin/no/nav/syfo/util/ExtractFromFellesFormat.kt
+++ b/src/main/kotlin/no/nav/syfo/util/ExtractFromFellesFormat.kt
@@ -45,7 +45,7 @@ fun extractLegeHpr(dialogmeldingId: String, fellesformat: XMLEIFellesformat): St
 }
 
 private fun isValidHpr(hprNr: String?) =
-    hprNr != null && hprNr.length <= 9 && hprNr.all { char -> char.isDigit() }
+    hprNr != null && hprNr.length > 0 && hprNr.length <= 9 && hprNr.all { char -> char.isDigit() }
 
 fun no.nav.helse.dialogmelding.XMLHealthcareProfessional.toBehandler(): Behandler = Behandler(
     fornavn = givenName ?: "",

--- a/src/main/kotlin/no/nav/syfo/util/ExtractFromFellesFormat.kt
+++ b/src/main/kotlin/no/nav/syfo/util/ExtractFromFellesFormat.kt
@@ -34,10 +34,15 @@ fun extractOrganisationHerNumberFromSender(fellesformat: XMLEIFellesformat): XML
 fun extractSenderOrganisationName(fellesformat: XMLEIFellesformat): String =
     fellesformat.get<XMLMsgHead>().msgInfo.sender.organisation?.organisationName ?: ""
 
-fun extractLegeHpr(fellesformat: XMLEIFellesformat): String? =
-    fellesformat.get<XMLMsgHead>().msgInfo.sender.organisation?.healthcareProfessional?.ident?.find {
+fun extractLegeHpr(fellesformat: XMLEIFellesformat): String? {
+    val hpr = fellesformat.get<XMLMsgHead>().msgInfo.sender.organisation?.healthcareProfessional?.ident?.find {
         it.typeId.v == "HPR"
     }?.id
+    return if (isValidHpr(hpr)) hpr else null
+}
+
+private fun isValidHpr(hprNr: String?) =
+    hprNr != null && hprNr.length <= 9 && hprNr.all { char -> char.isDigit() }
 
 fun no.nav.helse.dialogmelding.XMLHealthcareProfessional.toBehandler(): Behandler = Behandler(
     fornavn = givenName ?: "",

--- a/src/test/kotlin/no/nav/syfo/dialogmelding/BlockingApplicationRunnerSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmelding/BlockingApplicationRunnerSpek.kt
@@ -146,6 +146,18 @@ class BlockingApplicationRunnerSpek : Spek({
                     verify(exactly = 0) { mqSender.sendArena(any()) }
                     verify(exactly = 0) { dialogmeldingProducer.sendDialogmelding(any(), any(), any(), any()) }
                 }
+                it("Prosesserer innkommet melding (ugyldig hpr-nr)") {
+                    val fellesformat = getFileAsString("src/test/resources/dialogmelding_dialog_notat.xml")
+                        .replace("<Id>1234567</Id>", "<Id>-1234567</Id>")
+                    every { incomingMessage.text } returns(fellesformat)
+                    runBlocking {
+                        blockingApplicationRunner.processMessageHandleException(incomingMessage)
+                    }
+                    verify(exactly = 1) { mqSender.sendReceipt(any()) }
+                    verify(exactly = 0) { mqSender.sendBackout(any()) }
+                    verify(exactly = 1) { mqSender.sendArena(any()) }
+                    verify(exactly = 1) { dialogmeldingProducer.sendDialogmelding(any(), any(), any(), any()) }
+                }
                 it("Prosesserer innkommet melding (duplikat)") {
                     val fellesformat =
                         getFileAsString("src/test/resources/dialogmelding_dialog_notat.xml")

--- a/src/test/kotlin/no/nav/syfo/kafka/DialogmeldingProducerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kafka/DialogmeldingProducerTest.kt
@@ -163,6 +163,7 @@ internal class DialogmeldingProducerTest {
     fun setupTestData(inputMessageText: String) {
         fellesformat = fellesformatUnmarshaller.unmarshal(StringReader(inputMessageText)) as XMLEIFellesformat
 
+        val dialogmeldingId = UUID.randomUUID().toString()
         val receiverBlock = fellesformat.get<XMLMottakenhetBlokk>()
         val ediLoggId = receiverBlock.ediLoggId
         val msgId = fellesformat.get<XMLMsgHead>().msgInfo.msgId
@@ -173,10 +174,9 @@ internal class DialogmeldingProducerTest {
         val legekontorOrgName = extractSenderOrganisationName(fellesformat)
         val legekontorHerId = extractOrganisationHerNumberFromSender(fellesformat)?.id
         val dialogmeldingType = findDialogmeldingType(receiverBlock.ebService, receiverBlock.ebAction)
-        val legeHpr = extractLegeHpr(fellesformat)
+        val legeHpr = extractLegeHpr(dialogmeldingId, fellesformat)
 
         val dialomeldingxml = extractDialogmelding(fellesformat)
-        val dialogmeldingId = UUID.randomUUID().toString()
         val signaturDato = LocalDateTime.of(2017, 11, 5, 0, 0, 0)
         val navnHelsePersonellNavn = "Per Hansen"
 

--- a/src/test/kotlin/no/nav/syfo/mock/DokarkivMock.kt
+++ b/src/test/kotlin/no/nav/syfo/mock/DokarkivMock.kt
@@ -44,7 +44,10 @@ class DokarkivMock {
             routing {
                 post {
                     val journalpostRequest = call.receive<JournalpostRequest>()
-                    if (journalpostRequest.bruker!!.id != UserConstants.PATIENT_FNR_NO_AKTOER_ID) {
+                    if (
+                        journalpostRequest.bruker!!.id != UserConstants.PATIENT_FNR_NO_AKTOER_ID &&
+                        !journalpostRequest.avsenderMottaker!!.id!!.contains('-')
+                    ) {
                         call.respond(journalpostResponse)
                     } else {
                         call.respond(HttpStatusCode.InternalServerError)


### PR DESCRIPTION
Problemet med dialogmeldingen som feiler i padm2 nå er at hpr-nummeret til behandleren inneholder en '-', så det kan ikke brukes for journalføring.

Vi kan fint prosessere meldingen uten hprnr (det er ikke et påkrevd felt).

