### PR TITLE
Skip Kafka-publish for large message

### DIFF
--- a/src/main/resources/db/migration/V4_9__skip_kafka_publish_large_message.sql
+++ b/src/main/resources/db/migration/V4_9__skip_kafka_publish_large_message.sql
@@ -1,0 +1,1 @@
+UPDATE DIALOGMELDINGOPPLYSNINGER SET dialogmelding_published=now() WHERE msg_id='61c03f76-0eee-45b9-ba62-ae1bb178823d';


### PR DESCRIPTION
Foreslår at vi løser problemet denne gangen med å ikke publisere meldingen på Kafka - det gjøres ved å bare sette et timestamp i den aktuelle kolonnen. Melding er en henvendelse fra lege som skal til Arena.