### PR TITLE
Retry if 4xx from syfohelsenettproxy

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/DialogmeldingProcessor.kt
+++ b/src/main/kotlin/no/nav/syfo/application/DialogmeldingProcessor.kt
@@ -54,7 +54,7 @@ class DialogmeldingProcessor(
     val syfohelsenettproxyClient = SyfohelsenettproxyClient(
         azureAdV2Client = azureAdV2Client,
         endpointUrl = env.syfohelsenettproxyEndpointURL,
-        httpClient = httpClient,
+        httpClient = httpClientRetryAll,
         helsenettClientId = env.syfohelsenettproxyClientId,
     )
     val legeSuspensjonClient = LegeSuspensjonClient(

--- a/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
+++ b/src/main/kotlin/no/nav/syfo/client/HttpClientCommon.kt
@@ -23,6 +23,19 @@ val commonConfig: HttpClientConfig<out HttpClientEngineConfig>.() -> Unit = {
     expectSuccess = true
 }
 
+val retryAllConfig: HttpClientConfig<out HttpClientEngineConfig>.() -> Unit = {
+    install(ContentNegotiation) {
+        jackson { configure() }
+    }
+    install(HttpRequestRetry) {
+        retryOnExceptionIf(2) { _, cause ->
+            cause is ServerResponseException || cause is ClientRequestException
+        }
+        constantDelay(500L)
+    }
+    expectSuccess = true
+}
+
 val proxyConfig: HttpClientConfig<ApacheEngineConfig>.() -> Unit = {
     this.commonConfig()
     engine {
@@ -33,4 +46,5 @@ val proxyConfig: HttpClientConfig<ApacheEngineConfig>.() -> Unit = {
 }
 
 val httpClient = HttpClient(Apache, commonConfig)
+val httpClientRetryAll = HttpClient(Apache, retryAllConfig)
 val httpClientWithProxy = HttpClient(Apache, proxyConfig)


### PR DESCRIPTION
Vi hadde et tilfelle der en dialogmeldiing ble avvist fordi behandleren ikke ble funnet av syfohelsenettproxy (404-feil), men dette var bare et sporadisk tilfelle (syfohelsenettproxy returnerte 200 for samme behandler både før og etter). 

Så for å redusere sannsynligheten for at dette skjer igjen foreslår jeg at vi gjør tilsvarende retry som ved andre feil også når responsen er 404.