### PR TITLE
IS-1645: Use servicediscovery for syfohelsenettproxy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+### Hva har blitt lagt til✨🌈
+
+Hva er nytt / hva har blitt fikset?

--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -110,7 +110,7 @@ spec:
     - name: HELSENETT_CLIENT_ID
       value: dev-gcp.teamsykmelding.syfohelsenettproxy
     - name: HELSENETT_ENDPOINT_URL
-      value: http://syfohelsenettproxy
+      value: http://syfohelsenettproxy.teamsykmelding
     - name: LEGE_SUSPENSJON_CLIENT_ID
       value: dev-fss.teamsykefravr.isproxy
     - name: LEGE_SUSPENSJON_ENDPOINT_URL

--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -110,7 +110,7 @@ spec:
     - name: HELSENETT_CLIENT_ID
       value: dev-gcp.teamsykmelding.syfohelsenettproxy
     - name: HELSENETT_ENDPOINT_URL
-      value: https://syfohelsenettproxy
+      value: http://syfohelsenettproxy
     - name: LEGE_SUSPENSJON_CLIENT_ID
       value: dev-fss.teamsykefravr.isproxy
     - name: LEGE_SUSPENSJON_ENDPOINT_URL

--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -53,7 +53,6 @@ spec:
               port: 1413
               protocol: TCP
         - host: "dokarkiv.dev-fss-pub.nais.io"
-        - host: "syfohelsenettproxy.dev-fss-pub.nais.io"
         - host: "isproxy.dev-fss-pub.nais.io"
         - host: "pdl-api.dev-fss-pub.nais.io"
       rules:
@@ -61,6 +60,8 @@ spec:
         - application: clamav
           namespace: nais-system
         - application: smtss
+          namespace: teamsykmelding
+        - application: syfohelsenettproxy
           namespace: teamsykmelding
   azure:
     application:
@@ -107,9 +108,9 @@ spec:
     - name: PDL_ENDPOINT_URL
       value: https://pdl-api.dev-fss-pub.nais.io/graphql
     - name: HELSENETT_CLIENT_ID
-      value: dev-fss.teamsykmelding.syfohelsenettproxy
+      value: dev-gcp.teamsykmelding.syfohelsenettproxy
     - name: HELSENETT_ENDPOINT_URL
-      value: https://syfohelsenettproxy.dev-fss-pub.nais.io
+      value: https://syfohelsenettproxy
     - name: LEGE_SUSPENSJON_CLIENT_ID
       value: dev-fss.teamsykefravr.isproxy
     - name: LEGE_SUSPENSJON_ENDPOINT_URL

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -53,7 +53,6 @@ spec:
               port: 1414
               protocol: TCP
         - host: "dokarkiv.prod-fss-pub.nais.io"
-        - host: "syfohelsenettproxy.prod-fss-pub.nais.io"
         - host: "isproxy.prod-fss-pub.nais.io"
         - host: "pdl-api.prod-fss-pub.nais.io"
       rules:
@@ -61,6 +60,8 @@ spec:
         - application: clamav
           namespace: nais-system
         - application: smtss
+          namespace: teamsykmelding
+        - application: syfohelsenettproxy
           namespace: teamsykmelding
   azure:
     application:
@@ -107,9 +108,9 @@ spec:
     - name: PDL_ENDPOINT_URL
       value: https://pdl-api.prod-fss-pub.nais.io/graphql
     - name: HELSENETT_CLIENT_ID
-      value: prod-fss.teamsykmelding.syfohelsenettproxy
+      value: prod-gcp.teamsykmelding.syfohelsenettproxy
     - name: HELSENETT_ENDPOINT_URL
-      value: https://syfohelsenettproxy.prod-fss-pub.nais.io
+      value: https://syfohelsenettproxy
     - name: LEGE_SUSPENSJON_CLIENT_ID
       value: prod-fss.teamsykefravr.isproxy
     - name: LEGE_SUSPENSJON_ENDPOINT_URL

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -110,7 +110,7 @@ spec:
     - name: HELSENETT_CLIENT_ID
       value: prod-gcp.teamsykmelding.syfohelsenettproxy
     - name: HELSENETT_ENDPOINT_URL
-      value: http://syfohelsenettproxy
+      value: http://syfohelsenettproxy.teamsykmelding
     - name: LEGE_SUSPENSJON_CLIENT_ID
       value: prod-fss.teamsykefravr.isproxy
     - name: LEGE_SUSPENSJON_ENDPOINT_URL

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -110,7 +110,7 @@ spec:
     - name: HELSENETT_CLIENT_ID
       value: prod-gcp.teamsykmelding.syfohelsenettproxy
     - name: HELSENETT_ENDPOINT_URL
-      value: https://syfohelsenettproxy
+      value: http://syfohelsenettproxy
     - name: LEGE_SUSPENSJON_CLIENT_ID
       value: prod-fss.teamsykefravr.isproxy
     - name: LEGE_SUSPENSJON_ENDPOINT_URL


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Team sykmelding skrev til oss på Slack, og de har flyttet appen til GCP. Derfor kan vi bytte ut litt config for å snakke med GCP-versjonen av appen i stedet for on-prem 🙌🏼

Noe jeg har glemt? Kan teste at det funker i dev først.