### PR TITLE
IS-1682: Move start of rerun cronjob so it does not start at the same time as arena cronjob

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/RerunCronJob.kt
+++ b/src/main/kotlin/no/nav/syfo/application/RerunCronJob.kt
@@ -13,7 +13,7 @@ class RerunCronJob(
     val database: DatabaseInterface,
     val dialogmeldingProcessor: DialogmeldingProcessor,
 ) : Cronjob {
-    override val initialDelayMinutes: Long = 2
+    override val initialDelayMinutes: Long = 7
     override val intervalDelayMinutes: Long = 10
 
     override suspend fun run() {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
For å være litt mer robuste, så ønsker vi å spre de to cronjobbene ut litt i tid, ettersom de går like ofte. Bedre at de går litt alternerende enn samtidig hver gang.