### PR TITLE
IS-1716: Remove unsupported yaml-format

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -49,9 +49,7 @@ spec:
         - host: "login.microsoftonline.com"
         - host: "b27apvl222.preprod.local"
           ports:
-            - name: MQ
-              port: 1413
-              protocol: TCP
+          - port: 1413
         - host: "dokarkiv.dev-fss-pub.nais.io"
         - host: "pdl-api.dev-fss-pub.nais.io"
         - host: "btsys.dev-fss-pub.nais.io"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -49,9 +49,7 @@ spec:
         - host: "login.microsoftonline.com"
         - host: "mpls04.adeo.no"
           ports:
-            - name: MQ
-              port: 1414
-              protocol: TCP
+          - port: 1414
         - host: "dokarkiv.prod-fss-pub.nais.io"
         - host: "pdl-api.prod-fss-pub.nais.io"
         - host: "btsys.prod-fss-pub.nais.io"


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Se slack: https://nav-it.slack.com/archives/G01ABN2E885/p1697809881164999
Vi fikk en warning i loggene når vi deployet padm2, fordi `name` ikke var gjenkjent blant annet.
