### PR TITLE
IS-1731: Add column sent_to_arena-flag

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/SendDialogmeldingArenaCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/application/SendDialogmeldingArenaCronjob.kt
@@ -42,7 +42,10 @@ class SendDialogmeldingArenaCronjob(
                     receivedDialogmelding = receivedDialogmelding,
                     fellesformatXml = fellesformatXml
                 )
-                database.lagreSendtArena(dialogmeldingId)
+                database.lagreSendtArena(
+                    dialogmeldingid = dialogmeldingId,
+                    isSent = true,
+                )
                 result.updated++
             } catch (e: Exception) {
                 log.error("Caught exception in sending dialogmelding to arena", e)

--- a/src/main/kotlin/no/nav/syfo/handlestatus/HandleStatusOK.kt
+++ b/src/main/kotlin/no/nav/syfo/handlestatus/HandleStatusOK.kt
@@ -58,7 +58,10 @@ suspend fun handleStatusOK(
             ),
             loggingMeta
         )
-        database.lagreSendtArena(receivedDialogmelding.dialogmelding.id)
+        database.lagreSendtArena(
+            dialogmeldingid = receivedDialogmelding.dialogmelding.id,
+            isSent = true,
+        )
     }
 
     if (!database.erDialogmeldingOpplysningerSendtKafka(receivedDialogmelding.dialogmelding.id)) {

--- a/src/main/kotlin/no/nav/syfo/persistering/db/PersisterDialogmeldingQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/persistering/db/PersisterDialogmeldingQueries.kt
@@ -175,23 +175,25 @@ fun DatabaseInterface.erDialogmeldingOpplysningerSendtArena(dialogmeldingid: Str
 
 private const val queryUpdateArenaSendt = """
     UPDATE DIALOGMELDINGOPPLYSNINGER
-    SET ARENA=?
-    WHERE ID=?;
+    SET arena = ?, is_sent_to_arena = ?
+    WHERE id = ?;
 """
 
-fun DatabaseInterface.lagreSendtArena(dialogmeldingid: String) {
+fun DatabaseInterface.lagreSendtArena(dialogmeldingid: String, isSent: Boolean) {
     connection.use { connection ->
         connection.lagreSendtArena(
             dialogmeldingId = dialogmeldingid,
+            isSent = isSent,
             commit = true,
         )
     }
 }
 
-fun Connection.lagreSendtArena(dialogmeldingId: String, commit: Boolean = false) {
+fun Connection.lagreSendtArena(dialogmeldingId: String, isSent: Boolean, commit: Boolean = false) {
     prepareStatement(queryUpdateArenaSendt).use {
         it.setTimestamp(1, Timestamp.valueOf(LocalDateTime.now()))
-        it.setString(2, dialogmeldingId)
+        it.setBoolean(2, isSent)
+        it.setString(3, dialogmeldingId)
         val updated = it.executeUpdate()
         if (updated != 1) {
             throw SQLException("Expected a single row to be updated, got update count $updated")

--- a/src/main/kotlin/no/nav/syfo/persistering/db/PersisterDialogmeldingQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/persistering/db/PersisterDialogmeldingQueries.kt
@@ -54,7 +54,7 @@ fun Connection.opprettDialogmeldingOpplysninger(receivedDialogmelding: ReceivedD
                 dialogmelding_published,
                 arena,
                 apprec,
-                is_sent_to_arena
+                sent_to_arena
                 )
             VALUES  (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             RETURNING id
@@ -175,7 +175,7 @@ fun DatabaseInterface.erDialogmeldingOpplysningerSendtArena(dialogmeldingid: Str
 
 private const val queryUpdateArenaSendt = """
     UPDATE DIALOGMELDINGOPPLYSNINGER
-    SET arena = ?, is_sent_to_arena = ?
+    SET arena = ?, sent_to_arena = ?
     WHERE id = ?;
 """
 

--- a/src/main/kotlin/no/nav/syfo/persistering/db/PersisterDialogmeldingQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/persistering/db/PersisterDialogmeldingQueries.kt
@@ -53,9 +53,10 @@ fun Connection.opprettDialogmeldingOpplysninger(receivedDialogmelding: ReceivedD
                 journalforing,
                 dialogmelding_published,
                 arena,
-                apprec
+                apprec,
+                is_sent_to_arena
                 )
-            VALUES  (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES  (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             RETURNING id
             """
     ).use {
@@ -72,6 +73,7 @@ fun Connection.opprettDialogmeldingOpplysninger(receivedDialogmelding: ReceivedD
         it.setNull(11, Types.TIMESTAMP)
         it.setNull(12, Types.TIMESTAMP)
         it.setNull(13, Types.TIMESTAMP)
+        it.setBoolean(14, false)
         it.executeQuery().toList { getString("id") }
     }
 

--- a/src/main/resources/db/migration/V5_1__add_column_is_sendt_to_arena.sql
+++ b/src/main/resources/db/migration/V5_1__add_column_is_sendt_to_arena.sql
@@ -1,0 +1,6 @@
+ALTER TABLE DIALOGMELDINGOPPLYSNINGER
+    ADD COLUMN is_sent_to_arena BOOLEAN DEFAULT FALSE;
+
+UPDATE dialogmeldingopplysninger
+SET is_sent_to_arena = TRUE
+WHERE arena IS NOT NULL;

--- a/src/main/resources/db/migration/V5_1__add_column_sendt_to_arena.sql
+++ b/src/main/resources/db/migration/V5_1__add_column_sendt_to_arena.sql
@@ -1,6 +1,6 @@
 ALTER TABLE DIALOGMELDINGOPPLYSNINGER
-    ADD COLUMN is_sent_to_arena BOOLEAN DEFAULT FALSE;
+    ADD COLUMN sent_to_arena BOOLEAN DEFAULT FALSE;
 
 UPDATE dialogmeldingopplysninger
-SET is_sent_to_arena = TRUE
+SET sent_to_arena = TRUE
 WHERE arena IS NOT NULL;

--- a/src/test/kotlin/no/nav/syfo/TestDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/TestDatabase.kt
@@ -2,6 +2,7 @@ package no.nav.syfo
 
 import com.opentable.db.postgres.embedded.EmbeddedPostgres
 import no.nav.syfo.db.DatabaseInterface
+import no.nav.syfo.db.toList
 import org.flywaydb.core.Flyway
 import java.sql.Connection
 import java.sql.SQLException
@@ -72,5 +73,25 @@ fun DatabaseInterface.updateSendtApprec(dialogmeldingId: String, timestamp: Time
             }
         }
         connection.commit()
+    }
+}
+
+fun DatabaseInterface.getSentToArena(dialogmeldingId: String): Pair<Timestamp, Boolean>? {
+    connection.use { connection ->
+        return connection.prepareStatement(
+            """
+                SELECT arena, is_sent_to_arena
+                FROM dialogmeldingopplysninger
+                WHERE id = ?;
+                """
+        ).use {
+            it.setString(1, dialogmeldingId)
+            it.executeQuery().toList {
+                Pair(
+                    first = getTimestamp("arena"),
+                    second = getBoolean("is_sent_to_arena")
+                )
+            }.firstOrNull()
+        }
     }
 }

--- a/src/test/kotlin/no/nav/syfo/TestDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/TestDatabase.kt
@@ -80,7 +80,7 @@ fun DatabaseInterface.getSentToArena(dialogmeldingId: String): Pair<Timestamp, B
     connection.use { connection ->
         return connection.prepareStatement(
             """
-                SELECT arena, is_sent_to_arena
+                SELECT arena, sent_to_arena
                 FROM dialogmeldingopplysninger
                 WHERE id = ?;
                 """
@@ -89,7 +89,7 @@ fun DatabaseInterface.getSentToArena(dialogmeldingId: String): Pair<Timestamp, B
             it.executeQuery().toList {
                 Pair(
                     first = getTimestamp("arena"),
-                    second = getBoolean("is_sent_to_arena")
+                    second = getBoolean("sent_to_arena")
                 )
             }.firstOrNull()
         }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

For å holde orden på hvilke meldinger vi ikke skal plukke opp i cronjobben fra https://github.com/navikt/padm2/pull/219, må vi ha et felt i databasen som sier om meldingen er sjekket (mot feks isbehandlerdialog), men ikke skal sendes. Hvis ikke vil den for alltid dukke opp i cronjobben siden meldingen vil slå ut på den sjekken som gjøres der.

Tanken her nå er at man har et flag som sier om den er sendt til arena eller ikke, og at den gamle `arena`-kolonnen (et timestamp) som sjekket dette før, nå skal holde orden på om arena-sending har blitt sjekket eller ikke. I fremtiden vil derfor alle få dette `arena`-feltet (med mindre det ble negativ apprec), og cronjobben vil ikke plukke opp disse lenger.
