### PR TITLE
IS-2812: Gi AAP tilgang til Kafka-topic og vedlegg-api

### DIFF
--- a/.nais/kafka/dialogmelding.yaml
+++ b/.nais/kafka/dialogmelding.yaml
@@ -34,3 +34,6 @@ spec:
     - team: disykefravar
       application: dvh-sykefravar-airflow-kafka
       access: read
+    - team: aap
+      application: dokumentinnhenting
+      access: read

--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -45,6 +45,8 @@ spec:
     inbound:
       rules:
         - application: isbehandlerdialog
+        - application: dokumentinnhenting
+          namespace: aap
     outbound:
       external:
         - host: "login.microsoftonline.com"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -45,6 +45,8 @@ spec:
     inbound:
       rules:
         - application: isbehandlerdialog
+        - application: dokumentinnhenting
+          namespace: aap
     outbound:
       external:
         - host: "login.microsoftonline.com"

--- a/src/main/kotlin/no/nav/syfo/Environment.kt
+++ b/src/main/kotlin/no/nav/syfo/Environment.kt
@@ -45,8 +45,10 @@ data class Environment(
     val serviceuserUsername: String = getEnvVar("SERVICEUSER_USERNAME"),
     val serviceuserPassword: String = getEnvVar("SERVICEUSER_PASSWORD"),
     private val isbehandlerdialogApplicationName: String = "isbehandlerdialog",
+    private val dokumentinnhentingApplicationName: String = "dokumentinnhenting",
     val systemAPIAuthorizedConsumerApplicationNames: List<String> = listOf(
         isbehandlerdialogApplicationName,
+        dokumentinnhentingApplicationName,
     ),
     val smtssApiUrl: String = getEnvVar("SMTSS_URL"),
     val smtssClientId: String = getEnvVar("SMTSS_CLIENT_ID"),


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

AAP må ha tilgang for å finne innkommende dialogmeldinger som er svar på dialogmeldinger de har sendt.
