### PR TITLE
IS-3392: Skip Kafka-publish for large message

### DIFF
--- a/src/main/resources/db/migration/V5_9__skip_kafka_publish_large_message.sql
+++ b/src/main/resources/db/migration/V5_9__skip_kafka_publish_large_message.sql
@@ -1,0 +1,1 @@
+UPDATE DIALOGMELDINGOPPLYSNINGER SET dialogmelding_published=now() WHERE msg_id='ca51851e-cf15-4bd3-9aa1-1af4d8f33938';


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

En melding er for stor for å legges på Kafka, men ser ellers ut til å være ok (og skal antakelig til saksbehandler i Arena). PDF-generering og journalføring har gått ok etter noen forsøk (selv om PDF-generering tok 50s).
