### PR TITLE
IS-3455: Filename is quoted when it has whitspaces

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/ClamAvClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/ClamAvClient.kt
@@ -23,7 +23,7 @@ class ClamAvClient(
                         value = vedlegg.contentBase64,
                         headers = Headers.build {
                             append(HttpHeaders.ContentType, vedlegg.mimeType)
-                            append(HttpHeaders.ContentDisposition, "filename=${vedlegg.beskrivelse.replaceCRLF()}")
+                            append(HttpHeaders.ContentDisposition, "filename=\"${vedlegg.beskrivelse.replaceCRLF()}\"")
                         }
                     )
                 }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Vi får feil ved prosessering av dialogmelding.
Kopi av https://github.com/navikt/pale-2/commit/12945ca30c8f397b99ccdba047df8d93fbf65878

Se diskusjon: https://nav-it.slack.com/archives/C01958ML2M6/p1759472371348989