### PR TITLE
IS: Handle non 8-bit images

### DIFF
--- a/src/main/kotlin/no/nav/syfo/model/Vedlegg.kt
+++ b/src/main/kotlin/no/nav/syfo/model/Vedlegg.kt
@@ -3,7 +3,7 @@ package no.nav.syfo.model
 import no.nav.helse.base64container.Base64Container
 import no.nav.helse.msgHead.XMLDocument
 import no.nav.syfo.logger
-import no.nav.syfo.util.ImageToPDF
+import no.nav.syfo.util.convertImageToPDF
 import java.io.ByteArrayOutputStream
 
 data class Vedlegg(
@@ -28,7 +28,7 @@ fun Vedlegg.toPDFVedlegg(): Vedlegg {
     logger.info("Converting vedlegg of type ${this.mimeType} to PDFA")
 
     val image = ByteArrayOutputStream().use { outputStream ->
-        ImageToPDF(this.contentBase64.inputStream(), outputStream)
+        convertImageToPDF(this.contentBase64.inputStream(), outputStream)
         outputStream.toByteArray()
     }
 

--- a/src/main/kotlin/no/nav/syfo/util/ImageUtils.kt
+++ b/src/main/kotlin/no/nav/syfo/util/ImageUtils.kt
@@ -14,11 +14,11 @@ import java.awt.image.BufferedImage
 import java.io.*
 import javax.imageio.ImageIO
 
-fun ImageToPDF(imageStream: InputStream, outputStream: OutputStream) {
+fun convertImageToPDF(imageStream: InputStream, outputStream: OutputStream) {
     PDDocument().use { document ->
         val page = PDPage(PDRectangle.A4)
         document.addPage(page)
-        val image = toPortait(ImageIO.read(imageStream))
+        val image = toPortait(toRgb(ImageIO.read(imageStream)))
 
         val quality = 1.0f
 
@@ -31,6 +31,33 @@ fun ImageToPDF(imageStream: InputStream, outputStream: OutputStream) {
 
         document.save(outputStream)
     }
+}
+
+/**
+ * Konverterer et [BufferedImage] til fargemodellen TYPE_INT_RGB (standard 8-bit RGB).
+ *
+ * Noen bilder som mottas som vedlegg kan ha uvanlige fargemodeller, for eksempel:
+ * - CMYK (brukt i trykksaker)
+ * - 16-bit per kanal (høy fargdybde)
+ * - Bilder med alfakanal (gjennomsiktighet)
+ *
+ * JPEG-enkodingen i PDFBox (`JPEGFactory.createFromImage`) støtter kun bilder med
+ * 8-bit per kanal i RGB-format. Hvis bildet ikke er i riktig format, kastes feilen:
+ * "Illegal band size: should be 0 < size <= 8"
+ *
+ * Denne funksjonen tegner bildet inn i et nytt, tomt TYPE_INT_RGB-bilde slik at alle
+ * kanaler normaliseres til 8-bit RGB, uansett hva originalformatet var.
+ */
+private fun toRgb(image: BufferedImage): BufferedImage {
+    if (image.type == BufferedImage.TYPE_INT_RGB) {
+        return image
+    }
+    val rgbImage = BufferedImage(image.width, image.height, BufferedImage.TYPE_INT_RGB)
+    rgbImage.createGraphics().apply {
+        drawImage(image, 0, 0, null)
+        dispose()
+    }
+    return rgbImage
 }
 
 private fun toPortait(image: BufferedImage): BufferedImage {

--- a/src/test/kotlin/no/nav/syfo/util/ImageUtilsTest.kt
+++ b/src/test/kotlin/no/nav/syfo/util/ImageUtilsTest.kt
@@ -1,0 +1,44 @@
+package no.nav.syfo.util
+
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Test
+import java.awt.Transparency
+import java.awt.color.ColorSpace
+import java.awt.image.BufferedImage
+import java.awt.image.ComponentColorModel
+import java.awt.image.DataBuffer
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+
+class ImageUtilsTest {
+
+    /**
+     * Lager et 16-bit per kanal PNG-bilde. Dette er det problematiske formatet som
+     * foraarsaket feilen "Illegal band size: should be 0 < size <= 8" i JPEGFactory,
+     * fordi JPEG-enkodingen kun støtter 8-bit kanaler.
+     */
+    private fun create16BitPngInputStream(): ByteArrayInputStream {
+        val colorModel = ComponentColorModel(
+            ColorSpace.getInstance(ColorSpace.CS_sRGB),
+            intArrayOf(16, 16, 16),
+            false,
+            false,
+            Transparency.OPAQUE,
+            DataBuffer.TYPE_USHORT
+        )
+        val raster = colorModel.createCompatibleWritableRaster(100, 100)
+        val image = BufferedImage(colorModel, raster, false, null)
+        return ByteArrayOutputStream().use { baos ->
+            ImageIO.write(image, "png", baos)
+            ByteArrayInputStream(baos.toByteArray())
+        }
+    }
+
+    @Test
+    fun `convertImageToPDF skal haandtere 16-bit PNG uten aa kaste feil`() {
+        assertDoesNotThrow {
+            convertImageToPDF(create16BitPngInputStream(), ByteArrayOutputStream())
+        }
+    }
+}


### PR DESCRIPTION
Based on error: `javax.imageio.IIOException: Illegal band size: should be 0 < size <= 8.`

See https://logs.az.nav.no/app/discover?security_tenant=navlogs#/doc/c4992d50-be41-11f0-aab5-1ff58dd1d822/.ds-logs.nais-000209?id=IfXqpZ0B3JRICmU-gc_M

Et lite samarbeid med copilot for å fikse feilen i padm2, men litt usikker på om vi vil gå for noe sånt eller skippe prosesseringen i stedet. Burde i så fall testes at dette ble riktig.