### PR TITLE
IS-3881: Fjerne riktige vedlegg i DialogmeldingProducer

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/ArenaDialogNotat.kt
+++ b/src/main/kotlin/no/nav/syfo/client/ArenaDialogNotat.kt
@@ -5,6 +5,7 @@ import no.nav.helse.arenadialognotat.*
 import no.nav.helse.eiFellesformat2.XMLEIFellesformat
 import no.nav.helse.eiFellesformat2.XMLMottakenhetBlokk
 import no.nav.helse.msgHead.XMLMsgHead
+import no.nav.helse.msgHead.XMLPatient
 import no.nav.syfo.application.mq.MQSenderInterface
 import no.nav.syfo.logger
 import no.nav.syfo.metrics.TSS_MISS_COUNTER
@@ -21,7 +22,8 @@ fun createArenaDialogNotat(
     innbyggerident: String,
     msgHead: XMLMsgHead,
     emottakblokk: XMLMottakenhetBlokk,
-    dialogmelding: Dialogmelding
+    dialogmelding: Dialogmelding,
+    patient: XMLPatient,
 ): ArenaDialogNotat =
     ArenaDialogNotat().apply {
         val dialogmeldingXml = extractDialogmelding(fellesformat)
@@ -45,9 +47,9 @@ fun createArenaDialogNotat(
             person = PersonType().apply {
                 personFnr = innbyggerident
                 personNavn = NavnType().apply {
-                    fornavn = msgHead.msgInfo.patient.givenName
-                    mellomnavn = msgHead.msgInfo.patient?.middleName ?: ""
-                    etternavn = msgHead.msgInfo.patient.familyName
+                    fornavn = patient.givenName
+                    mellomnavn = patient.middleName ?: ""
+                    etternavn = patient.familyName
                 }
             }
         }

--- a/src/main/kotlin/no/nav/syfo/kafka/DialogmeldingProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/DialogmeldingProducer.kt
@@ -89,5 +89,12 @@ class DialogmeldingProducer(
 }
 
 fun XMLEIFellesformat.removeVedlegg() {
-    this.get<XMLMsgHead>().document.removeAll { it.isVedlegg() }
+    val outerMsgHead = this.get<XMLMsgHead>()
+    val firstXmlDoc = outerMsgHead.document.firstOrNull { it.refDoc.msgType.v == "XML" }
+    val innerMsgHead = firstXmlDoc?.refDoc?.content?.any?.firstOrNull { it is XMLMsgHead } as? XMLMsgHead
+    if (innerMsgHead != null) {
+        innerMsgHead.document.removeAll { it.isVedlegg() }
+    } else {
+        outerMsgHead.document.removeAll { it.isVedlegg() }
+    }
 }

--- a/src/main/kotlin/no/nav/syfo/services/ArenaDialogmeldingService.kt
+++ b/src/main/kotlin/no/nav/syfo/services/ArenaDialogmeldingService.kt
@@ -35,6 +35,9 @@ class ArenaDialogmeldingService(
             msgHead = msgHead,
             emottakBlokk = emottakBlokk,
         )
+        val patient = extractPatient(
+            fellesformat = fellesformatXml,
+        )
         val arenaDialogNotat = createArenaDialogNotat(
             fellesformat = fellesformatXml,
             tssid = tssId,
@@ -43,6 +46,7 @@ class ArenaDialogmeldingService(
             msgHead = msgHead,
             emottakblokk = emottakBlokk,
             dialogmelding = receivedDialogmelding.dialogmelding,
+            patient = patient,
         )
 
         sendArenaDialogNotat(

--- a/src/test/kotlin/no/nav/syfo/CreateArenaDialogNotatTest.kt
+++ b/src/test/kotlin/no/nav/syfo/CreateArenaDialogNotatTest.kt
@@ -52,7 +52,8 @@ internal class CreateArenaDialogNotatTest {
             personNumberPatient,
             msgHead,
             emottakblokk,
-            dialogmelding
+            dialogmelding,
+            msgHead.msgInfo.patient,
         )
 
         assertEquals("DM", arenaDialogNotat.eiaDokumentInfo.dokumentInfo.dokumentType)
@@ -124,7 +125,8 @@ internal class CreateArenaDialogNotatTest {
             personNumberPatient,
             msgHead,
             emottakblokk,
-            dialogmelding
+            dialogmelding,
+            msgHead.msgInfo.patient,
         )
 
         assertEquals("DM", arenaDialogNotat.eiaDokumentInfo.dokumentInfo.dokumentType)
@@ -187,7 +189,8 @@ internal class CreateArenaDialogNotatTest {
             personNumberPatient,
             msgHead,
             emottakblokk,
-            dialogmelding
+            dialogmelding,
+            msgHead.msgInfo.patient,
         )
 
         assertEquals("DM", arenaDialogNotat.eiaDokumentInfo.dokumentInfo.dokumentType)
@@ -245,7 +248,8 @@ internal class CreateArenaDialogNotatTest {
             personNumberPatient,
             msgHead,
             emottakblokk,
-            dialogmelding
+            dialogmelding,
+            msgHead.msgInfo.patient,
         )
 
         assertEquals("45088649080", arenaDialogNotat.pasientData.person.personFnr)
@@ -284,7 +288,8 @@ internal class CreateArenaDialogNotatTest {
             personNumberPatient,
             msgHead,
             emottakblokk,
-            dialogmelding
+            dialogmelding,
+            msgHead.msgInfo.patient,
         )
 
         assertEquals("3", arenaDialogNotat.notatKategori)
@@ -325,7 +330,8 @@ internal class CreateArenaDialogNotatTest {
             personNumberPatient,
             msgHead,
             emottakblokk,
-            dialogmelding
+            dialogmelding,
+            msgHead.msgInfo.patient,
         )
 
         assertEquals("Hei,Det gjelder pas. Sender sm2013 som vedlegg", arenaDialogNotat.notatTekst)

--- a/src/test/kotlin/no/nav/syfo/FromKiropraktorTest.kt
+++ b/src/test/kotlin/no/nav/syfo/FromKiropraktorTest.kt
@@ -60,7 +60,8 @@ class FromKiropraktorTest {
             innbyggerident = extractInnbyggerident(fellesformat) ?: "",
             msgHead = msgHead,
             emottakblokk = emottakblokk,
-            dialogmelding = dialogmelding
+            dialogmelding,
+            msgHead.msgInfo.patient,
         )
 
         assertEquals("Henvendelse til NAV", arenaDialogNotat.eiaDokumentInfo.dokumentInfo.dokumentNavn)

--- a/src/test/kotlin/no/nav/syfo/services/ArenaDialogmeldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/services/ArenaDialogmeldingServiceTest.kt
@@ -98,4 +98,22 @@ class ArenaDialogmeldingServiceTest {
         coVerify(exactly = 1) { smtssClient.findBestTss(legePersonIdent, legekontorOrgName, msgId) }
         coVerify(exactly = 0) { emottakService.registerEmottakSubscription(any(), any(), any(), any(), any()) }
     }
+
+    @Test
+    fun `Send to Arena with Pridok-bug`() {
+        val dialogmeldingString = getFileAsString("src/test/resources/dialogmelding_dialog_notat_pridok_bug.xml")
+        val fellesformat = safeUnmarshal(dialogmeldingString)
+        val receivedDialogmelding = ReceivedDialogmelding.create(
+            dialogmeldingId = msgId,
+            fellesformat = fellesformat,
+            inputMessageText = dialogmeldingString,
+        )
+        coEvery { smtssClient.findBestTss(any(), any(), any()) } returns tssId
+        coJustRun { emottakService.registerEmottakSubscription(any(), any(), any(), any(), any()) }
+
+        runBlocking {
+            arenaDialogmeldingService.sendArenaDialogmeldingToMQ(receivedDialogmelding, fellesformat)
+        }
+        coVerify(exactly = 1) { mqSender.sendArena(any()) }
+    }
 }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Copilot fant noe jeg har oversett: før vi legger fellesformat-xml'en på Kafka-topic må vi fjerne vedlegg (ellers kan record'en bli for stor).  For de meldingene som har Pridok-feilen må vedleggene fjernes fra den nøstede msgHead'en.
