### PR TITLE
Remove prefix when publishing

### DIFF
--- a/src/main/kotlin/no/nav/syfo/kafka/DialogmeldingProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/DialogmeldingProducer.kt
@@ -51,7 +51,7 @@ class DialogmeldingProducer(
     ): DialogmeldingForKafka {
         val xmlMsgInfo = msgHead.msgInfo
         return DialogmeldingForKafka(
-            msgId = xmlMsgInfo.msgId,
+            msgId = stripPrefix(xmlMsgInfo.msgId),
             msgType = xmlMsgInfo.type.v,
             navLogId = receivedDialogmelding.navLogId,
             mottattTidspunkt = receivedDialogmelding.mottattDato,
@@ -80,6 +80,10 @@ class DialogmeldingProducer(
             }.marshal(fellesformat, it)
             it.toString()
         }
+    }
+
+    private fun stripPrefix(msgId: String): String {
+        return msgId.removePrefix(SYFO_MOCK_PREFIX)
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/syfo/services/ApprecService.kt
+++ b/src/main/kotlin/no/nav/syfo/services/ApprecService.kt
@@ -9,6 +9,7 @@ import no.nav.syfo.apprec.ApprecStatus
 import no.nav.syfo.apprec.createApprec
 import no.nav.syfo.logger
 import no.nav.syfo.metrics.APPREC_COUNTER
+import no.nav.syfo.util.SYFO_MOCK_PREFIX
 import no.nav.syfo.util.get
 import no.nav.syfo.util.getApprecMarshaller
 import no.nav.syfo.util.toString
@@ -34,4 +35,4 @@ fun sendReceipt(
 }
 
 private fun isTestDialogmelding(msgId: String): Boolean =
-    msgId.startsWith("syfomock-")
+    msgId.startsWith(SYFO_MOCK_PREFIX)

--- a/src/main/kotlin/no/nav/syfo/util/Utils.kt
+++ b/src/main/kotlin/no/nav/syfo/util/Utils.kt
@@ -4,6 +4,10 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
 
+
+// Used as msgId-prefix for test messages from isyfomock
+const val SYFO_MOCK_PREFIX = "syfomock-"
+
 fun getFileAsString(filePath: String) = String(Files.readAllBytes(Paths.get(filePath)), StandardCharsets.UTF_8)
 
 fun getFileAsStringISO88591(filePath: String) = String(Files.readAllBytes(Paths.get(filePath)), StandardCharsets.ISO_8859_1)

--- a/src/test/kotlin/no/nav/syfo/kafka/DialogmeldingProducerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kafka/DialogmeldingProducerTest.kt
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.ZoneOffset
-import kotlin.text.removePrefix
 
 internal class DialogmeldingProducerTest {
 

--- a/src/test/kotlin/no/nav/syfo/kafka/DialogmeldingProducerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kafka/DialogmeldingProducerTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.ZoneOffset
+import kotlin.text.removePrefix
 
 internal class DialogmeldingProducerTest {
 
@@ -56,6 +57,31 @@ internal class DialogmeldingProducerTest {
         assertEquals(0, dialogmeldingForKafka.antallVedlegg)
         assertEquals(msgHead.msgInfo.conversationRef.refToConversation, dialogmeldingForKafka.conversationRef)
         assertEquals(msgHead.msgInfo.conversationRef.refToParent, dialogmeldingForKafka.parentRef)
+    }
+
+    @Test
+    internal fun `Tester mapping fra fellesformat til Kafka topic for dialogmeldinger fra isyfomock`() {
+        setupTestData(
+            getFileAsStringISO88591("src/test/resources/dialogmelding_dialog_notat.xml").replace(
+                "<MsgId>37340D30-FE14-42B5-985F-A8FF8FFA0CB5</MsgId>",
+                "<MsgId>syfomock-37340D30-FE14-42B5-985F-A8FF8FFA0CB5</MsgId>"
+            )
+        )
+
+        dialogmeldingProducer.sendDialogmelding(
+            receivedDialogmelding = receivedDialogmelding,
+            msgHead = msgHead,
+            journalpostId = journalpostId,
+            antallVedlegg = fellesformat.calculateNumberOfVedlegg(),
+        )
+        val slot = slot<ProducerRecord<String, DialogmeldingForKafka>>()
+
+        verify { kafkaProducerMock.send(capture(slot)) }
+
+        val producerRecord = slot.captured
+        assertEquals("teamsykefravr.dialogmelding", producerRecord.topic())
+        val dialogmeldingForKafka = producerRecord.value()
+        assertEquals(msgHead.msgInfo.msgId.removePrefix(SYFO_MOCK_PREFIX), dialogmeldingForKafka.msgId)
     }
 
     @Test


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Fjerner test-prefikset som brukes fra isyfomock når dialogmeldinger publiseres på Kafka: Kelvin foretrekker gyldig UUID her.

(dette prefikset ble innført på et tidligere tidspunkt for at padm2 skulle gjenkjenne dialogmeldinger fra isyfomock og la være å sende apprec for disse)
