### PR TITLE
IS-4032: Fjerne syfomock-prefiks ved publisering

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -136,3 +136,5 @@ spec:
       value: "dev-gcp.teamsykefravr.isbehandlerdialog"
     - name: ISBEHANDLERDIALOG_ENDPOINT_URL
       value: "http://isbehandlerdialog"
+    - name: IS_DEV_GCP
+      value: "true"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -136,3 +136,5 @@ spec:
       value: "prod-gcp.teamsykefravr.isbehandlerdialog"
     - name: ISBEHANDLERDIALOG_ENDPOINT_URL
       value: "http://isbehandlerdialog"
+    - name: IS_DEV_GCP
+      value: "false"

--- a/src/main/kotlin/no/nav/syfo/Environment.kt
+++ b/src/main/kotlin/no/nav/syfo/Environment.kt
@@ -57,6 +57,7 @@ data class Environment(
     val smgcpProxyClientId: String = getEnvVar("SMGCP_PROXY_CLIENT_ID"),
     val isbehandlerdialogClientId: String = getEnvVar("ISBEHANDLERDIALOG_CLIENT_ID"),
     val isbehandlerdialogUrl: String = getEnvVar("ISBEHANDLERDIALOG_ENDPOINT_URL"),
+    val isDevGcp: Boolean = getEnvVar("IS_DEV_GCP", "false").toBoolean(),
 ) : MqConfig {
     fun jdbcUrl(): String {
         return "jdbc:postgresql://$databaseHost:$databasePort/$databaseName"

--- a/src/main/kotlin/no/nav/syfo/application/mq/MQSender.kt
+++ b/src/main/kotlin/no/nav/syfo/application/mq/MQSender.kt
@@ -35,8 +35,12 @@ class MQSender(
     }
 
     override fun sendReceipt(payload: String) {
-        val queueName = env.apprecQueueName
-        send(queueName, payload)
+        if (!env.isDevGcp) {
+            val queueName = env.apprecQueueName
+            send(queueName, payload)
+        } else {
+            log.info("Not sending receipt to MQ in dev-gcp")
+        }
     }
 
     override fun sendBackout(message: Message) {

--- a/src/main/kotlin/no/nav/syfo/services/ApprecService.kt
+++ b/src/main/kotlin/no/nav/syfo/services/ApprecService.kt
@@ -3,11 +3,9 @@ package no.nav.syfo.services
 import no.nav.helse.apprecV1.XMLAppRec
 import no.nav.helse.apprecV1.XMLCV
 import no.nav.helse.eiFellesformat2.XMLEIFellesformat
-import no.nav.helse.msgHead.XMLMsgHead
 import no.nav.syfo.application.mq.MQSenderInterface
 import no.nav.syfo.apprec.ApprecStatus
 import no.nav.syfo.apprec.createApprec
-import no.nav.syfo.logger
 import no.nav.syfo.metrics.APPREC_COUNTER
 import no.nav.syfo.util.get
 import no.nav.syfo.util.getApprecMarshaller
@@ -19,19 +17,10 @@ fun sendReceipt(
     apprecStatus: ApprecStatus,
     apprecErrors: List<XMLCV> = listOf()
 ) {
-    val msgHead: XMLMsgHead = fellesformat.get()
-    val msgId = msgHead.msgInfo.msgId
-    if (isTestDialogmelding(msgId)) {
-        logger.info("Msgid $msgId is test-dialogmelding from syfomock - skipping sending of apprec")
-    } else {
-        val apprec = createApprec(fellesformat, apprecStatus)
-        apprec.get<XMLAppRec>().error.addAll(apprecErrors)
-        mqSender.sendReceipt(
-            payload = getApprecMarshaller().toString(apprec)
-        )
-        APPREC_COUNTER.increment()
-    }
+    val apprec = createApprec(fellesformat, apprecStatus)
+    apprec.get<XMLAppRec>().error.addAll(apprecErrors)
+    mqSender.sendReceipt(
+        payload = getApprecMarshaller().toString(apprec)
+    )
+    APPREC_COUNTER.increment()
 }
-
-private fun isTestDialogmelding(msgId: String): Boolean =
-    msgId.startsWith("syfomock-")

--- a/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
@@ -49,6 +49,7 @@ fun testEnvironment() = Environment(
     isbehandlerdialogClientId = "isbehandlerdialog",
     isbehandlerdialogUrl = "http://isbehandlerdialog",
     jpRetryEnabled = true,
+    isDevGcp = false,
 )
 
 fun testAppState() = ApplicationState(

--- a/src/test/kotlin/no/nav/syfo/dialogmelding/BlockingApplicationRunnerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmelding/BlockingApplicationRunnerTest.kt
@@ -142,24 +142,6 @@ class BlockingApplicationRunnerTest {
     }
 
     @Test
-    fun `Prosesserer innkommet test-melding fra syfomock (melding ok)`() {
-        val fellesformat =
-            getFileAsString("src/test/resources/dialogmelding_dialog_notat.xml")
-                .replace(
-                    "<MsgId>37340D30-FE14-42B5-985F-A8FF8FFA0CB5</MsgId>",
-                    "<MsgId>syfomock-37340D30-FE14-42B5-985F-A8FF8FFA0CB5</MsgId>"
-                )
-        every { incomingMessage.text } returns (fellesformat)
-        runBlocking {
-            blockingApplicationRunner.processMessage(incomingMessage)
-        }
-        verify(exactly = 0) { mqSender.sendReceipt(any()) }
-        verify(exactly = 0) { mqSender.sendBackout(any()) }
-        verify(exactly = 0) { mqSender.sendArena(any()) }
-        verify(exactly = 1) { dialogmeldingProducer.sendDialogmelding(any(), any(), any(), any()) }
-    }
-
-    @Test
     fun `Prosesserer innkommet melding (melding ok, men pdf-gen feiler)`() {
         val fellesformat =
             getFileAsString("src/test/resources/dialogmelding_dialog_notat.xml")


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

"Løsningen" vi har for å unngå apprecs i dev-gcp er uheldig siden vi lager ugyldige uuid'er for dialogmeldingene. 

Så bedre å gjøre det på en annen måte.

Lager PR i `isyfomock` etterpå.
